### PR TITLE
fix: .gitignore build/ rule excludes Tools/Build/ plugin sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__/
 *.py[cod]
 *.egg-info/
 dist/
-build/
+/build/
 .venv/
 .pytest_cache/
 .coverage

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Build/BuildAndRelaunchTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Build/BuildAndRelaunchTool.cpp
@@ -1,0 +1,180 @@
+// Copyright soft-ue-expert. All Rights Reserved.
+#include "Tools/Build/BuildAndRelaunchTool.h"
+#include "SoftUEBridgeEditorModule.h"
+#include "HAL/PlatformProcess.h"
+#include "Misc/Paths.h"
+#include "Misc/FileHelper.h"
+#include "Editor.h"
+
+FString UBuildAndRelaunchTool::GetToolDescription() const
+{
+	return TEXT("Close THIS editor instance (identified by PID), trigger a full project build, and relaunch the editor. Only affects the MCP-connected editor instance, not other running editors.");
+}
+
+TMap<FString, FBridgeSchemaProperty> UBuildAndRelaunchTool::GetInputSchema() const
+{
+	TMap<FString, FBridgeSchemaProperty> Schema;
+
+	FBridgeSchemaProperty BuildConfig;
+	BuildConfig.Type = TEXT("string");
+	BuildConfig.Description = TEXT("Build configuration: Development, Debug, or Shipping (default: Development)");
+	BuildConfig.bRequired = false;
+	Schema.Add(TEXT("build_config"), BuildConfig);
+
+	FBridgeSchemaProperty SkipRelaunch;
+	SkipRelaunch.Type = TEXT("boolean");
+	SkipRelaunch.Description = TEXT("Skip relaunching the editor after build (default: false)");
+	SkipRelaunch.bRequired = false;
+	Schema.Add(TEXT("skip_relaunch"), SkipRelaunch);
+
+	return Schema;
+}
+
+FBridgeToolResult UBuildAndRelaunchTool::Execute(
+	const TSharedPtr<FJsonObject>& Arguments,
+	const FBridgeToolContext& Context)
+{
+#if PLATFORM_WINDOWS
+	FString BuildConfig = GetStringArgOrDefault(Arguments, TEXT("build_config"), TEXT("Development"));
+	bool bSkipRelaunch = GetBoolArgOrDefault(Arguments, TEXT("skip_relaunch"), false);
+
+	// Validate build configuration
+	if (BuildConfig != TEXT("Development") && BuildConfig != TEXT("Debug") && BuildConfig != TEXT("Shipping"))
+	{
+		return FBridgeToolResult::Error(FString::Printf(TEXT("Invalid build configuration: %s. Must be Development, Debug, or Shipping."), *BuildConfig));
+	}
+
+	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("build-and-relaunch: Starting build and relaunch workflow (Config: %s, SkipRelaunch: %s)"), *BuildConfig, bSkipRelaunch ? TEXT("true") : TEXT("false"));
+
+	// Get project paths
+	FString ProjectPath = FPaths::GetProjectFilePath();
+	if (ProjectPath.IsEmpty())
+	{
+		return FBridgeToolResult::Error(TEXT("Could not determine project path"));
+	}
+	FString ProjectName = FPaths::GetBaseFilename(ProjectPath);
+	FString ProjectDir = FPaths::GetPath(ProjectPath);
+
+	// Get engine paths
+	FString EngineDir = FPaths::EngineDir();
+	FString BuildBatchFile = FPaths::Combine(EngineDir, TEXT("Build/BatchFiles/Build.bat"));
+	FString EditorExecutable = FPaths::Combine(EngineDir, TEXT("Binaries/Win64/UnrealEditor.exe"));
+
+	if (!FPaths::FileExists(BuildBatchFile))
+	{
+		return FBridgeToolResult::Error(FString::Printf(TEXT("Build script not found: %s"), *BuildBatchFile));
+	}
+	if (!bSkipRelaunch && !FPaths::FileExists(EditorExecutable))
+	{
+		return FBridgeToolResult::Error(FString::Printf(TEXT("Editor executable not found: %s"), *EditorExecutable));
+	}
+
+	// Create a batch script to handle the workflow
+	FString TempScriptPath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Temp"), TEXT("BuildAndRelaunch.bat"));
+	FString TempScriptDir = FPaths::GetPath(TempScriptPath);
+
+	// Ensure temp directory exists
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	if (!PlatformFile.DirectoryExists(*TempScriptDir))
+	{
+		if (!PlatformFile.CreateDirectoryTree(*TempScriptDir))
+		{
+			return FBridgeToolResult::Error(FString::Printf(TEXT("Failed to create temp directory: %s"), *TempScriptDir));
+		}
+	}
+
+	// Get current process ID to wait for specifically this instance
+	uint32 CurrentPID = FPlatformProcess::GetCurrentProcessId();
+
+	// Build the batch script
+	FString BatchScript = TEXT("@echo off\n");
+	BatchScript += FString::Printf(TEXT("echo Waiting for Unreal Editor (PID: %d) to close...\n"), CurrentPID);
+	BatchScript += TEXT("\n");
+
+	// Wait for this specific process to exit (not just any editor)
+	BatchScript += TEXT(":WAIT_LOOP\n");
+	BatchScript += FString::Printf(TEXT("tasklist /FI \"PID eq %d\" 2>NUL | find \"%d\" >NUL\n"), CurrentPID, CurrentPID);
+	BatchScript += TEXT("if %ERRORLEVEL% EQU 0 (\n");
+	BatchScript += TEXT("    timeout /t 1 /nobreak >nul\n");
+	BatchScript += TEXT("    goto WAIT_LOOP\n");
+	BatchScript += TEXT(")\n");
+	BatchScript += TEXT("echo Editor closed.\n");
+	BatchScript += TEXT("\n");
+
+	// Build command
+	BatchScript += FString::Printf(TEXT("echo Building %s (%s)...\n"), *ProjectName, *BuildConfig);
+	BatchScript += FString::Printf(TEXT("call \"%s\" %sEditor Win64 %s \"%s\" -waitmutex\n"), *BuildBatchFile, *ProjectName, *BuildConfig, *ProjectPath);
+	BatchScript += TEXT("\n");
+
+	BatchScript += TEXT("if %ERRORLEVEL% NEQ 0 (\n");
+	BatchScript += TEXT("    echo Build failed with error code %ERRORLEVEL%\n");
+	BatchScript += TEXT("    pause\n");
+	BatchScript += TEXT("    exit /b %ERRORLEVEL%\n");
+	BatchScript += TEXT(")\n");
+	BatchScript += TEXT("\n");
+
+	// Relaunch command (if not skipped)
+	if (!bSkipRelaunch)
+	{
+		BatchScript += TEXT("echo Build completed successfully. Relaunching editor...\n");
+		BatchScript += TEXT("timeout /t 2 /nobreak >nul\n");
+		BatchScript += FString::Printf(TEXT("start \"\" \"%s\" \"%s\"\n"), *EditorExecutable, *ProjectPath);
+	}
+	else
+	{
+		BatchScript += TEXT("echo Build completed successfully.\n");
+	}
+
+	BatchScript += TEXT("\n");
+	BatchScript += FString::Printf(TEXT("del \"%s\"\n"), *TempScriptPath);
+
+	// Write the batch script
+	if (!FFileHelper::SaveStringToFile(BatchScript, *TempScriptPath))
+	{
+		return FBridgeToolResult::Error(FString::Printf(TEXT("Failed to create batch script: %s"), *TempScriptPath));
+	}
+	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("build-and-relaunch: Created batch script at: %s"), *TempScriptPath);
+
+	// Launch the batch script via cmd.exe
+	FString CmdArgs = FString::Printf(TEXT("/c \"%s\""), *TempScriptPath);
+	FProcHandle ProcHandle = FPlatformProcess::CreateProc(
+		TEXT("cmd.exe"),
+		*CmdArgs,
+		true,  // bLaunchDetached
+		false, // bLaunchHidden
+		false, // bLaunchReallyHidden
+		nullptr,
+		0,     // PriorityModifier
+		nullptr,
+		nullptr
+	);
+
+	if (!ProcHandle.IsValid())
+	{
+		return FBridgeToolResult::Error(TEXT("Failed to launch build script"));
+	}
+
+	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("build-and-relaunch: Batch script launched successfully (PID: %d). Requesting editor shutdown..."), CurrentPID);
+
+	// Build result
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("status"), TEXT("initiated"));
+	Result->SetStringField(TEXT("project"), *ProjectName);
+	Result->SetStringField(TEXT("build_config"), *BuildConfig);
+	Result->SetBoolField(TEXT("will_relaunch"), !bSkipRelaunch);
+	Result->SetNumberField(TEXT("editor_pid"), CurrentPID);
+	Result->SetStringField(TEXT("message"), FString::Printf(TEXT("Build and relaunch workflow initiated for this editor instance (PID: %d). Editor will close momentarily."), CurrentPID));
+
+	// Request editor shutdown with a small delay to allow the response to be sent
+	FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateLambda([](float DeltaTime) -> bool {
+		FPlatformMisc::RequestExit(false);
+		return false; // Don't repeat
+	}), 1.0f);
+
+	return FBridgeToolResult::Json(Result);
+
+#else
+	return FBridgeToolResult::Error(TEXT("build-and-relaunch is only supported on Windows"));
+#endif
+}

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Build/TriggerLiveCodingTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Build/TriggerLiveCodingTool.cpp
@@ -1,0 +1,181 @@
+// Copyright soft-ue-expert. All Rights Reserved.
+
+#include "Tools/Build/TriggerLiveCodingTool.h"
+#include "SoftUEBridgeEditorModule.h"
+#include "Engine/Engine.h"
+#include "Modules/ModuleManager.h"
+
+// Live Coding module (Windows only)
+#if PLATFORM_WINDOWS
+	#include "ILiveCodingModule.h"
+#endif
+
+FString UTriggerLiveCodingTool::GetToolDescription() const
+{
+	return TEXT("Trigger Live Coding compilation for C++ code changes. Supports synchronous mode with wait_for_completion. Windows only.");
+}
+
+TMap<FString, FBridgeSchemaProperty> UTriggerLiveCodingTool::GetInputSchema() const
+{
+	TMap<FString, FBridgeSchemaProperty> Schema;
+
+	FBridgeSchemaProperty WaitForCompletion;
+	WaitForCompletion.Type = TEXT("boolean");
+	WaitForCompletion.Description = TEXT("Wait for compilation to complete before returning (default: false, async mode)");
+	WaitForCompletion.bRequired = false;
+	Schema.Add(TEXT("wait_for_completion"), WaitForCompletion);
+
+	return Schema;
+}
+
+FBridgeToolResult UTriggerLiveCodingTool::Execute(
+	const TSharedPtr<FJsonObject>& Arguments,
+	const FBridgeToolContext& Context)
+{
+	bool bWaitForCompletion = GetBoolArgOrDefault(Arguments, TEXT("wait_for_completion"), false);
+
+	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("trigger-live-coding: Triggering Live Coding compilation (wait=%d)"),
+		bWaitForCompletion);
+
+#if !PLATFORM_WINDOWS
+	return FBridgeToolResult::Error(TEXT("Live Coding is only supported on Windows"));
+#else
+
+	// Try to use ILiveCodingModule for better control
+	ILiveCodingModule* LiveCodingModule = FModuleManager::GetModulePtr<ILiveCodingModule>("LiveCoding");
+
+	if (!LiveCodingModule)
+	{
+		UE_LOG(LogSoftUEBridgeEditor, Warning, TEXT("trigger-live-coding: LiveCoding module not available, falling back to console command"));
+
+		// Fallback to console command
+		if (!GEngine || !GEngine->Exec(nullptr, TEXT("LiveCoding.Compile")))
+		{
+			return FBridgeToolResult::Error(TEXT("Failed to trigger Live Coding. Enable it in Editor Preferences > General > Live Coding."));
+		}
+
+		TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetStringField(TEXT("status"), TEXT("triggered_async"));
+		Result->SetStringField(TEXT("message"), TEXT("Live Coding triggered via console command"));
+		return FBridgeToolResult::Json(Result);
+	}
+
+	// Check if Live Coding is enabled
+	if (!LiveCodingModule->IsEnabledForSession())
+	{
+		return FBridgeToolResult::Error(TEXT("Live Coding is not enabled for this session. Enable it in Editor Preferences > General > Live Coding."));
+	}
+
+	if (bWaitForCompletion)
+	{
+		// Synchronous mode: Wait for compilation to complete
+		return ExecuteSynchronous(LiveCodingModule);
+	}
+	else
+	{
+		// Asynchronous mode: Just trigger and return immediately
+		return ExecuteAsynchronous(LiveCodingModule);
+	}
+#endif
+}
+
+#if PLATFORM_WINDOWS
+FBridgeToolResult UTriggerLiveCodingTool::ExecuteSynchronous(ILiveCodingModule* LiveCodingModule)
+{
+	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("trigger-live-coding: Starting synchronous compilation..."));
+
+	const double StartTime = FPlatformTime::Seconds();
+
+	// Use WaitForCompletion flag - this blocks until compilation finishes
+	ELiveCodingCompileResult CompileResult;
+	bool bStarted = LiveCodingModule->Compile(ELiveCodingCompileFlags::WaitForCompletion, &CompileResult);
+
+	const double CompilationTime = FPlatformTime::Seconds() - StartTime;
+
+	// Build result based on CompileResult
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetNumberField(TEXT("compilation_time_seconds"), CompilationTime);
+	Result->SetStringField(TEXT("shortcut"), TEXT("Ctrl+Alt+F11"));
+
+	// Map ELiveCodingCompileResult to response
+	FString StatusStr;
+	FString MessageStr;
+	bool bSuccess = false;
+
+	switch (CompileResult)
+	{
+	case ELiveCodingCompileResult::Success:
+		bSuccess = true;
+		StatusStr = TEXT("completed");
+		MessageStr = FString::Printf(TEXT("Live Coding compilation completed successfully in %.1fs"), CompilationTime);
+		UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("trigger-live-coding: Compilation successful (%.1fs)"), CompilationTime);
+		break;
+
+	case ELiveCodingCompileResult::NoChanges:
+		bSuccess = true;
+		StatusStr = TEXT("no_changes");
+		MessageStr = TEXT("No code changes detected - nothing to compile");
+		UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("trigger-live-coding: No changes detected"));
+		break;
+
+	case ELiveCodingCompileResult::Failure:
+		bSuccess = false;
+		StatusStr = TEXT("failed");
+		MessageStr = TEXT("Live Coding compilation failed. Check Output Log for errors.");
+		UE_LOG(LogSoftUEBridgeEditor, Warning, TEXT("trigger-live-coding: Compilation failed (%.1fs)"), CompilationTime);
+		break;
+
+	case ELiveCodingCompileResult::Cancelled:
+		bSuccess = false;
+		StatusStr = TEXT("cancelled");
+		MessageStr = TEXT("Live Coding compilation was cancelled");
+		UE_LOG(LogSoftUEBridgeEditor, Warning, TEXT("trigger-live-coding: Compilation cancelled"));
+		break;
+
+	case ELiveCodingCompileResult::CompileStillActive:
+		bSuccess = false;
+		StatusStr = TEXT("busy");
+		MessageStr = TEXT("A prior Live Coding compile is still in progress");
+		UE_LOG(LogSoftUEBridgeEditor, Warning, TEXT("trigger-live-coding: Compile still active"));
+		break;
+
+	case ELiveCodingCompileResult::NotStarted:
+		bSuccess = false;
+		StatusStr = TEXT("not_started");
+		MessageStr = TEXT("Live Coding monitor could not be started");
+		UE_LOG(LogSoftUEBridgeEditor, Warning, TEXT("trigger-live-coding: Could not start"));
+		break;
+
+	case ELiveCodingCompileResult::InProgress:
+	default:
+		bSuccess = false;
+		StatusStr = TEXT("unknown");
+		MessageStr = FString::Printf(TEXT("Unexpected compile result: %d"), static_cast<int32>(CompileResult));
+		UE_LOG(LogSoftUEBridgeEditor, Warning, TEXT("trigger-live-coding: Unexpected result %d"), static_cast<int32>(CompileResult));
+		break;
+	}
+
+	Result->SetBoolField(TEXT("success"), bSuccess);
+	Result->SetStringField(TEXT("status"), StatusStr);
+	Result->SetStringField(TEXT("message"), MessageStr);
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UTriggerLiveCodingTool::ExecuteAsynchronous(ILiveCodingModule* LiveCodingModule)
+{
+	// Just trigger compilation and return immediately
+	LiveCodingModule->Compile(ELiveCodingCompileFlags::None, nullptr);
+
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("status"), TEXT("triggered_async"));
+	Result->SetStringField(TEXT("message"), TEXT("Live Coding compilation initiated. Check Output Log for results."));
+	Result->SetStringField(TEXT("shortcut"), TEXT("Ctrl+Alt+F11"));
+
+	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("trigger-live-coding: Async compilation triggered"));
+
+	return FBridgeToolResult::Json(Result);
+}
+#endif

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Build/BuildAndRelaunchTool.h
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Build/BuildAndRelaunchTool.h
@@ -1,0 +1,38 @@
+// Copyright soft-ue-expert. All Rights Reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Tools/BridgeToolBase.h"
+#include "BuildAndRelaunchTool.generated.h"
+
+/**
+ * Close THIS editor instance, trigger a full project build, and relaunch the editor.
+ * This tool handles the complete workflow for rebuilding the project.
+ * Uses process ID (PID) to ensure only the MCP-connected editor instance is affected.
+ * Other running editor instances are not affected.
+ * Windows only.
+ */
+UCLASS()
+class SOFTUEBRIDGEEDITOR_API UBuildAndRelaunchTool : public UBridgeToolBase
+{
+	GENERATED_BODY()
+
+public:
+	virtual FString GetToolName() const override
+	{
+		return TEXT("build-and-relaunch");
+	}
+
+	virtual FString GetToolDescription() const override;
+	
+	virtual TMap<FString, FBridgeSchemaProperty> GetInputSchema() const override;
+	
+	virtual TArray<FString> GetRequiredParams() const override
+	{
+		return {};
+	}
+
+	virtual FBridgeToolResult Execute(
+		const TSharedPtr<FJsonObject>& Arguments,
+		const FBridgeToolContext& Context) override;
+};

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Build/TriggerLiveCodingTool.h
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Build/TriggerLiveCodingTool.h
@@ -1,0 +1,47 @@
+// Copyright soft-ue-expert. All Rights Reserved.
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Tools/BridgeToolBase.h"
+#include "TriggerLiveCodingTool.generated.h"
+
+#if PLATFORM_WINDOWS
+class ILiveCodingModule;
+#endif
+
+/**
+ * Trigger Live Coding compilation for C++ code changes.
+ * Equivalent to pressing Ctrl+Alt+F11 in the editor.
+ * Supports async (fire-and-forget) and sync (wait-for-result) modes.
+ * Windows only. Requires Live Coding enabled in Editor Preferences.
+ */
+UCLASS()
+class SOFTUEBRIDGEEDITOR_API UTriggerLiveCodingTool : public UBridgeToolBase
+{
+	GENERATED_BODY()
+
+public:
+	virtual FString GetToolName() const override
+	{
+		return TEXT("trigger-live-coding");
+	}
+
+	virtual FString GetToolDescription() const override;
+	
+	virtual TMap<FString, FBridgeSchemaProperty> GetInputSchema() const override;
+	
+	virtual TArray<FString> GetRequiredParams() const override
+	{
+		return {};
+	}
+
+	virtual FBridgeToolResult Execute(
+		const TSharedPtr<FJsonObject>& Arguments,
+		const FBridgeToolContext& Context) override;
+
+private:
+#if PLATFORM_WINDOWS
+	FBridgeToolResult ExecuteSynchronous(ILiveCodingModule* LiveCodingModule);
+	FBridgeToolResult ExecuteAsynchronous(ILiveCodingModule* LiveCodingModule);
+#endif
+};


### PR DESCRIPTION
The root .gitignore contains a build/ entry (line 5) intended for Python build artifacts. However, since this pattern has no leading slash, Git matches it against any directory named Build at any depth — including Source/SoftUEBridgeEditor/*/Tools/Build/.

This causes 4 source files to be silently excluded from the repository:

Public/Tools/Build/BuildAndRelaunchTool.h
Public/Tools/Build/TriggerLiveCodingTool.h
Private/Tools/Build/BuildAndRelaunchTool.cpp
Private/Tools/Build/TriggerLiveCodingTool.cpp
Users installing the plugin via soft-ue-cli setup will get a broken build with:
'''C1083: Cannot open include file: "Tools/Build/BuildAndRelaunchTool.h": No such file or directory'''