### PR TITLE
fix: config set crash, test-tools fixes, uasset format guard

### DIFF
--- a/soft_ue_cli/__main__.py
+++ b/soft_ue_cli/__main__.py
@@ -1545,7 +1545,11 @@ def _cmd_config_set(args: argparse.Namespace) -> None:
             continue
         ini = UeIniFile.from_file(layer.path) if layer.exists else UeIniFile(path=layer.path)
         ini.set(section, key, value)
-        ini.write(layer.path)
+        try:
+            ini.write(layer.path)
+        except PermissionError:
+            print(f"error: permission denied writing '{layer.path}' (file may be read-only or locked by source control)", file=sys.stderr)
+            sys.exit(1)
         _print_json({"status": "ok", "key": key_str, "value": value, "layer": layer_name, "path": str(layer.path)})
         return
 

--- a/soft_ue_cli/skills/test-tools.md
+++ b/soft_ue_cli/skills/test-tools.md
@@ -706,15 +706,11 @@ def _run_single_mode(mode_name: str, caller) -> list[dict]:
     begin_suite("config")
 
     # Bridge tools: get / set / validate
-    run_test("get-config-value r.Bloom", "get-config-value", {
+    # Use set-config-value's own test key for get — r.Bloom is a CVar,
+    # not an INI key, so get-config-value (which reads GConfig INI) won't find it.
+    run_test("validate-config-key r.DefaultFeature.AutoExposure", "validate-config-key", {
         "section": "/Script/Engine.RendererSettings",
-        "key": "r.Bloom",
-        "config_type": "Engine",
-    }, has("value"))
-
-    run_test("validate-config-key r.Bloom", "validate-config-key", {
-        "section": "/Script/Engine.RendererSettings",
-        "key": "r.Bloom",
+        "key": "r.DefaultFeature.AutoExposure",
         "config_type": "Engine",
     }, has("valid"))
 
@@ -740,8 +736,10 @@ def _run_single_mode(mode_name: str, caller) -> list[dict]:
             check_stdout=lambda s: '"format": "ini"' in s or '"layers": []' in s)
     offline_cfg_key = f"OfflineSearchKey_{RUN_TS}_{mode_name}"
     offline_cfg_path = f"[{cfg_section}]{offline_cfg_key}"
-    run_cli("config set project default", "config", *(["--project-path", project_dir] if project_dir else []),
-            "set", offline_cfg_path, "SearchValue42", "--layer", "ProjectDefault", "--type", "Engine",
+    # Write to GameDirUser layer (Config/UserEngine.ini) — less likely to be
+    # read-only under source control than ProjectDefault (Config/DefaultEngine.ini).
+    run_cli("config set user layer", "config", *(["--project-path", project_dir] if project_dir else []),
+            "set", offline_cfg_path, "SearchValue42", "--layer", "GameDirUser", "--type", "Engine",
             check_stdout=lambda s: '"status": "ok"' in s and offline_cfg_key in s)
     run_cli("config get search", "config", *(["--project-path", project_dir] if project_dir else []),
             "get", "--search", offline_cfg_key, "--type", "Engine",

--- a/soft_ue_cli/uasset/package.py
+++ b/soft_ue_cli/uasset/package.py
@@ -111,7 +111,16 @@ class UAssetPackage:
                 offset=0,
             )
 
-        r.read_int32()  # LegacyFileVersion
+        legacy_file_version = r.read_int32()  # LegacyFileVersion
+
+        if legacy_file_version <= -8:
+            raise UAssetError(
+                f"Unsupported package format version {legacy_file_version} "
+                f"(UE 5.4+ format). The offline parser only supports "
+                f"LegacyFileVersion -7 through -2 (UE 4.x / UE 5.0-5.3).",
+                offset=4,
+            )
+
         r.read_int32()  # LegacyUE3Version
         s.file_version_ue4 = r.read_int32()
         s.file_version_ue5 = r.read_int32()


### PR DESCRIPTION
## Summary

- **config set PermissionError** (#109): `_cmd_config_set` crashes with a Python traceback when writing to read-only INI files (e.g. Perforce-controlled `DefaultEngine.ini`). Now catches `PermissionError` and exits with a clear error message.

- **test-tools r.Bloom** (#107): `get-config-value r.Bloom` test was testing the wrong thing — `r.Bloom` is a console variable, not an INI key in `/Script/Engine.RendererSettings`. Removed the invalid test and kept `validate-config-key` with a real INI key (`r.DefaultFeature.AutoExposure`).

- **test-tools config set layer** (#109): Changed offline config set test from `ProjectDefault` (DefaultEngine.ini, often read-only under Perforce) to `GameDirUser` (UserEngine.ini, user-writable).

- **uasset parser format guard** (#108): UE 5.4+ (LegacyFileVersion <= -8) uses a different package header format that the offline parser doesn't support. Added an early check that raises a clear `UAssetError` with the version info, instead of silently reading garbage offsets and producing confusing "Expected N bytes" errors.

## Test plan

- [ ] Run `python test_tools.py` against a live UE 5.7 instance
- [ ] Verify `get-config-value r.Bloom` test is replaced with `validate-config-key`
- [ ] Verify `config set user layer` writes to UserEngine.ini without crash
- [ ] Verify `inspect-uasset` / `diff-uasset` show "Unsupported package format version -9" instead of binary offset errors
- [ ] Verify `config set` to a read-only file shows "permission denied" error, not a traceback

Fixes #107, #108, #109