### PR TITLE
Fix input validation errors and minor bugs

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(grep -r \"\\\\\\\\$\\\\|shell\\\\|bash\\\\|cmd\\\\|powershell\\\\|exec\\\\|system\" /c/Users/mistw/soft-ue-cli/soft_ue_cli --include=\"*.py\")",
+      "Bash(grep:*)",
+      "Bash(git checkout:*)",
+      "Bash(python -m pytest tests/ -x -q)",
+      "Bash(git stash:*)",
+      "Bash(python -m pytest tests/test_main.py::test_cmd_setup_contains_check_setup_command -x -q)",
+      "Bash(git add:*)",
+      "Bash(git commit -m ':*)",
+      "Bash(git push:*)",
+      "Bash(gh repo:*)",
+      "Bash(git remote:*)",
+      "Bash(gh pr:*)"
+    ]
+  }
+}

--- a/soft_ue_cli/__main__.py
+++ b/soft_ue_cli/__main__.py
@@ -78,6 +78,15 @@ def _parse_vector(csv: str) -> list[float]:
         sys.exit(1)
 
 
+def _parse_int_list(csv: str) -> list[int]:
+    """Parse a comma-separated string like '0,0,1920,1080' into a list of ints."""
+    try:
+        return [int(x) for x in csv.split(",")]
+    except ValueError:
+        print(f"error: expected comma-separated integers, got '{csv}'", file=sys.stderr)
+        sys.exit(1)
+
+
 def _parse_json_arg(value: str, flag: str) -> object:
     """Parse a JSON string, printing an error and exiting on failure."""
     try:
@@ -468,7 +477,7 @@ def cmd_capture_screenshot(args: argparse.Namespace) -> None:
     if args.window_name:
         arguments["window_name"] = args.window_name
     if args.region:
-        arguments["region"] = [int(x) for x in args.region.split(",")]
+        arguments["region"] = _parse_int_list(args.region)
     if args.format:
         arguments["format"] = args.format
     if args.output:
@@ -513,7 +522,11 @@ def cmd_query_mpc(args: argparse.Namespace) -> None:
         if val.startswith("["):
             arguments["value"] = _parse_json_arg(val, "--value")
         else:
-            arguments["value"] = float(val)
+            try:
+                arguments["value"] = float(val)
+            except ValueError:
+                print(f"error: expected a number or JSON array, got '{val}'", file=sys.stderr)
+                sys.exit(1)
     if args.world:
         arguments["world"] = args.world
     _print_json(_run_tool("query-mpc", arguments))
@@ -845,7 +858,7 @@ def cmd_add_graph_node(args: argparse.Namespace) -> None:
     if args.graph_name:
         arguments["graph_name"] = args.graph_name
     if args.position:
-        arguments["position"] = [int(x) for x in args.position.split(",")]
+        arguments["position"] = _parse_int_list(args.position)
     if args.no_auto_position:
         arguments["auto_position"] = False
     if args.connect_to_node:

--- a/soft_ue_cli/client.py
+++ b/soft_ue_cli/client.py
@@ -99,7 +99,7 @@ def call_tool(tool_name: str, arguments: dict[str, Any], timeout: float | None =
     # Parse text content as JSON when possible
     content = result.get("content", [])
     if content and content[0].get("type") == "text":
-        text = content[0]["text"]
+        text = content[0].get("text", "")
         try:
             return json.loads(text)
         except json.JSONDecodeError:

--- a/soft_ue_cli/testimonial.py
+++ b/soft_ue_cli/testimonial.py
@@ -41,7 +41,7 @@ def _build_issue_body(
 ) -> str:
     """Build the markdown body for the GitHub Issue."""
     attribution = agent_name or "Anonymous"
-    sections = [f"> {message}\n\n\\— {attribution}"]
+    sections = [f"> {message}\n\n— {attribution}"]
 
     meta_lines = [f"- CLI version: {cli_version}", f"- Streak: {streak} days"]
     if rating is not None:


### PR DESCRIPTION
## Summary
- Add `_parse_int_list()` helper to handle malformed numeric CLI arguments (`--region`, `--position`) with friendly error messages instead of tracebacks
- Wrap `float()` conversion in `query-mpc --value` with try/except for the same reason
- Fix stray backslash before em-dash in testimonial attribution
- Use `.get("text", "")` in `client.py` to avoid `KeyError` on unexpected server responses

## Test plan
- [ ] Run `capture-screenshot --region bad,input` and verify a clean error message
- [ ] Run `add-graph-node --position bad,input` and verify a clean error message
- [ ] Run `query-mpc --value notanumber` and verify a clean error message
- [ ] Verify normal numeric inputs still work for all three commands
- [ ] Confirm testimonial attribution renders without a stray backslash

🤖 Generated with [Claude Code](https://claude.com/claude-code)