### PR TITLE
Fix: query-material OOM crash caused by unbounded GetInput() loop

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Material/QueryMaterialTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Material/QueryMaterialTool.cpp
@@ -235,12 +235,17 @@ TSharedPtr<FJsonObject> UQueryMaterialTool::ExpressionToJson(UMaterialExpression
 		ExprJson->SetNumberField(TEXT("y"), Expression->MaterialExpressionEditorY);
 	}
 
-	// Inputs
+	// Inputs — use GetInputsView() for bounded iteration.
+	// IMPORTANT: Do NOT use the unbounded `for (i=0;;i++) GetInput(i)` pattern.
+	// Some expression subclasses (e.g. RVT samplers) never return nullptr from
+	// GetInput() on out-of-range indices, causing an infinite loop that
+	// allocates JSON objects until OOM.
 	TArray<TSharedPtr<FJsonValue>> InputsArray;
-	for (int32 i = 0; ; i++)
+	TArrayView<FExpressionInput*> Inputs = Expression->GetInputsView();
+	for (int32 i = 0; i < Inputs.Num(); i++)
 	{
-		FExpressionInput* Input = Expression->GetInput(i);
-		if (!Input) break;
+		FExpressionInput* Input = Inputs[i];
+		if (!Input) continue;
 
 		TSharedPtr<FJsonObject> InputJson = MakeShareable(new FJsonObject);
 		InputJson->SetStringField(TEXT("name"), Expression->GetInputName(i).ToString());


### PR DESCRIPTION
## Summary

Fixes a critical OOM crash in the `query-material` tool when querying materials containing certain expression types (e.g. Runtime Virtual Texture samplers).

## Root Cause

`ExpressionToJson()` used an unbounded `for (i=0;;i++) GetInput(i)` loop, relying on `nullptr` return to terminate. Some `UMaterialExpression` subclasses never return `nullptr` on out-of-range indices, causing an infinite loop that allocates JSON objects until OOM.