### PR TITLE
fix(plugin): resolve cli-v1.28.0 MSVC unity-build errors

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridge/Private/Tools/BridgeToolRegistry.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridge/Private/Tools/BridgeToolRegistry.cpp
@@ -73,11 +73,11 @@ int32 FBridgeToolRegistry::RemoveToolsForModule(const FString& ModuleName)
 
 	for (const FString& ToolName : ToolNamesToRemove)
 	{
-		if (TObjectPtr<UBridgeToolBase>* Instance = ToolInstances.Find(ToolName))
+		if (TObjectPtr<UBridgeToolBase>* ExistingInstance = ToolInstances.Find(ToolName))
 		{
-			if (Instance->Get())
+			if (ExistingInstance->Get())
 			{
-				Instance->Get()->RemoveFromRoot();
+				ExistingInstance->Get()->RemoveFromRoot();
 			}
 		}
 		ToolInstances.Remove(ToolName);

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
@@ -18,7 +18,7 @@
 
 namespace
 {
-	static bool ContainsToken(const FString& Source, std::initializer_list<const TCHAR*> Tokens)
+	static bool MatchesAnyToken(const FString& Source, std::initializer_list<const TCHAR*> Tokens)
 	{
 		for (const TCHAR* Token : Tokens)
 		{
@@ -47,7 +47,7 @@ namespace
 	static bool LooksLikeCustomizableObject(const UObject* Object)
 	{
 		return Object && Object->GetClass() &&
-			ContainsToken(Object->GetClass()->GetName(), {TEXT("CustomizableObject"), TEXT("Mutable")});
+			MatchesAnyToken(Object->GetClass()->GetName(), {TEXT("CustomizableObject"), TEXT("Mutable")});
 	}
 
 	static void CollectGraphs(UObject* AssetObject, TArray<UEdGraph*>& OutGraphs)
@@ -111,7 +111,7 @@ namespace
 		for (UEdGraph* Graph : Graphs)
 		{
 			if (Graph && Graph->GetClass() &&
-				ContainsToken(Graph->GetClass()->GetName(), {TEXT("CustomizableObject"), TEXT("Mutable")}))
+				MatchesAnyToken(Graph->GetClass()->GetName(), {TEXT("CustomizableObject"), TEXT("Mutable")}))
 			{
 				return Graph;
 			}


### PR DESCRIPTION
Two upstream-incompatible build errors when compiling on MSVC with UE's unity build (Development config, UE 5.6+):

## 1. `ContainsToken` duplicate definition (C2084)

`SoftUEBridgeEditor/Private/Tools/Asset/MutableIntrospectionUtils.cpp` and `EditCustomizableObjectGraphTool.cpp` both define an identical:

```cpp
namespace
{
    static bool ContainsToken(const FString& Source, std::initializer_list<const TCHAR*> Tokens)
```

UE's UBT concatenates module sources into a unity TU via `#include`. Anonymous-namespace blocks at file scope in the same TU are the *same* namespace, so the second definition collides:

```
MutableIntrospectionUtils.cpp(57,14): Error C2084 : function 'bool `anonymous-namespace'::ContainsToken(...)' already has a body
EditCustomizableObjectGraphTool.cpp(21,14): Reference  : see previous definition
```

Followed by ~30 cascading C2264 errors at every call site.

**Fix:** rename the helper in `EditCustomizableObjectGraphTool.cpp` to `MatchesAnyToken` (smaller blast radius — only 3 call sites in that file vs. 24+ in `MutableIntrospectionUtils.cpp`). Bodies are identical so behavior is unchanged.

## 2. `Instance` shadow in `BridgeToolRegistry::RemoveToolsForModule` (C4458)

```
BridgeToolRegistry.cpp(76,36): Error C4458 : declaration of 'Instance' hides class member
    if (TObjectPtr<UBridgeToolBase>* Instance = ToolInstances.Find(ToolName))
BridgeToolRegistry.h(49,30): see declaration of 'FBridgeToolRegistry::Instance'
```

UE treats C4458 as an error. **Fix:** rename the local to `ExistingInstance`.

## Verification

Errors reproduced from a Rider Development build on Windows (UE 5.6, MSVC). After applying these two renames, the same build now succeeds end-to-end. Fixes are mechanical renames with no behavior change.