### PR TITLE
fix: resolve C4996 deprecation warnings in asset/material query tools

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/QueryEnumTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/QueryEnumTool.cpp
@@ -42,7 +42,7 @@ FBridgeToolResult UQueryEnumTool::Execute(
 	}
 
 	IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
-	const FAssetData AssetData = AssetRegistry.GetAssetByObjectPath(FName(*AssetPath));
+	const FAssetData AssetData = AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(AssetPath));
 	UObject* AssetObject = AssetData.IsValid() ? AssetData.GetAsset() : nullptr;
 	UUserDefinedEnum* UserEnum = Cast<UUserDefinedEnum>(AssetObject);
 	if (!UserEnum)

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/QueryStructTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/QueryStructTool.cpp
@@ -42,7 +42,7 @@ FBridgeToolResult UQueryStructTool::Execute(
 	}
 
 	IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry").Get();
-	const FAssetData AssetData = AssetRegistry.GetAssetByObjectPath(FName(*AssetPath));
+	const FAssetData AssetData = AssetRegistry.GetAssetByObjectPath(FSoftObjectPath(AssetPath));
 	UObject* AssetObject = AssetData.IsValid() ? AssetData.GetAsset() : nullptr;
 	UUserDefinedStruct* UserStruct = Cast<UUserDefinedStruct>(AssetObject);
 	if (!UserStruct)

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Material/QueryMaterialTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Material/QueryMaterialTool.cpp
@@ -235,18 +235,16 @@ TSharedPtr<FJsonObject> UQueryMaterialTool::ExpressionToJson(UMaterialExpression
 		ExprJson->SetNumberField(TEXT("y"), Expression->MaterialExpressionEditorY);
 	}
 
-	// Inputs — use GetInputsView() for bounded iteration.
-	// Some expression subclasses never return nullptr from GetInput() on
-	// out-of-range indices, which can spin forever and OOM the editor.
+	// Inputs — FExpressionInputIterator is the engine's canonical bounded
+	// traversal. It advances via GetInput(Index) and stops when that returns
+	// nullptr (past CachedInputs.Num()), so it cannot run away.
 	TArray<TSharedPtr<FJsonValue>> InputsArray;
-	TArrayView<FExpressionInput*> Inputs = Expression->GetInputsView();
-	for (int32 i = 0; i < Inputs.Num(); i++)
+	for (FExpressionInputIterator It{ Expression }; It; ++It)
 	{
-		FExpressionInput* Input = Inputs[i];
-		if (!Input) continue;
+		FExpressionInput* Input = It.Input;
 
 		TSharedPtr<FJsonObject> InputJson = MakeShareable(new FJsonObject);
-		InputJson->SetStringField(TEXT("name"), Expression->GetInputName(i).ToString());
+		InputJson->SetStringField(TEXT("name"), Expression->GetInputName(It.Index).ToString());
 		InputJson->SetBoolField(TEXT("connected"), Input->Expression != nullptr);
 
 		if (Input->Expression)

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Material/QueryMaterialTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Material/QueryMaterialTool.cpp
@@ -235,9 +235,9 @@ TSharedPtr<FJsonObject> UQueryMaterialTool::ExpressionToJson(UMaterialExpression
 		ExprJson->SetNumberField(TEXT("y"), Expression->MaterialExpressionEditorY);
 	}
 
-	// Inputs — FExpressionInputIterator is the engine's canonical bounded
-	// traversal. It advances via GetInput(Index) and stops when that returns
-	// nullptr (past CachedInputs.Num()), so it cannot run away.
+	// Inputs — FExpressionInputIterator is the engine's bounded iterator
+	// (GetInputsView() was deprecated in 5.5). It stops as soon as
+	// GetInput(Index) returns nullptr, so it can't spin forever / OOM the editor.
 	TArray<TSharedPtr<FJsonValue>> InputsArray;
 	for (FExpressionInputIterator It{ Expression }; It; ++It)
 	{


### PR DESCRIPTION
## Summary
The SoftUEBridge editor plugin emits `C4996` deprecation warnings when built against UE 5.7. The engine states these APIs will become hard compile errors in the next release, so this updates them to the current APIs.

```
QueryEnumTool.cpp(45): warning C4996: IAssetRegistry::GetAssetByObjectPath: Asset path FNames have been deprecated, use Soft Object Path instead.
QueryMaterialTool.cpp(242): warning C4996: UMaterialExpression::GetInputsView: Use FExpressionInputIterator instead or GetInput() directly.
```

QueryStructTool carried the same deprecated `GetAssetByObjectPath(FName)` call; it doesn't always surface as a warning because of unity-build chunking, but it's the same deprecation and is fixed here too.

## Changes
- **QueryEnumTool**: `IAssetRegistry::GetAssetByObjectPath(FName)` → `GetAssetByObjectPath(FSoftObjectPath)`. The `FName` path overload is deprecated; `FSoftObjectPath` is constructed directly from the path string.
- **QueryStructTool**: same `GetAssetByObjectPath(FName)` → `GetAssetByObjectPath(FSoftObjectPath)` migration.
- **QueryMaterialTool**: `UMaterialExpression::GetInputsView()` → `FExpressionInputIterator`, the engine's canonical bounded traversal. It advances via `GetInput(Index)` and terminates when that returns `nullptr` past `CachedInputs.Num()`, preserving the original loop's bounded-iteration intent.

## Verification
C++ plugin changes — not compile-verified locally (requires the UE editor). Both replacement APIs were confirmed against the UE 5.7 engine headers (`Materials/MaterialExpression.h`, `IAssetRegistry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
