### PR TITLE
fix(plugin): resolve SegmentToJson unity-build collision in anim montage tools

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimMontageInspectTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimMontageInspectTool.cpp
@@ -54,7 +54,7 @@ FString ClassPathOrEmpty(const UObject* Object)
 	return Object && Object->GetClass() ? Object->GetClass()->GetPathName() : TEXT("");
 }
 
-TSharedPtr<FJsonObject> SegmentToJson(const FAnimSegment& Segment)
+TSharedPtr<FJsonObject> MontageInspectSegmentToJson(const FAnimSegment& Segment)
 {
 	TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
 	const UAnimSequenceBase* Animation = Segment.GetAnimReference();
@@ -180,7 +180,7 @@ FBridgeToolResult UAnimMontageInspectTool::Execute(
 			TArray<TSharedPtr<FJsonValue>> SegmentsJson;
 			for (const FAnimSegment& Segment : SlotTrack.AnimTrack.AnimSegments)
 			{
-				SegmentsJson.Add(MakeShared<FJsonValueObject>(SegmentToJson(Segment)));
+				SegmentsJson.Add(MakeShared<FJsonValueObject>(MontageInspectSegmentToJson(Segment)));
 			}
 			SlotJson->SetArrayField(TEXT("segments"), SegmentsJson);
 			SlotsJson.Add(MakeShared<FJsonValueObject>(SlotJson));

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimMontageSlotTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimMontageSlotTool.cpp
@@ -146,7 +146,7 @@ FAnimSegment BuildSegment(
 	return Segment;
 }
 
-TSharedPtr<FJsonObject> SegmentToJson(const FAnimSegment& Segment)
+TSharedPtr<FJsonObject> MontageSlotSegmentToJson(const FAnimSegment& Segment)
 {
 	TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
 	Json->SetStringField(
@@ -301,7 +301,7 @@ FBridgeToolResult UAnimMontageSetSlotAnimationTool::Execute(
 	Result->SetBoolField(TEXT("created_slot"), bCreatedSlot);
 	Result->SetNumberField(TEXT("replaced_segment_count"), ReplacedSegmentCount);
 	Result->SetNumberField(TEXT("sequence_length"), Montage->GetPlayLength());
-	Result->SetObjectField(TEXT("segment"), SegmentToJson(ResultSegment));
+	Result->SetObjectField(TEXT("segment"), MontageSlotSegmentToJson(ResultSegment));
 	Result->SetBoolField(TEXT("saved"), bSave);
 	return FBridgeToolResult::Json(Result);
 }


### PR DESCRIPTION
## Problem
`AnimMontageInspectTool.cpp` and `AnimMontageSlotTool.cpp` (added in cli-v1.38.0) each define a separate anonymous-namespace helper named `SegmentToJson`. Under MSVC **unity builds** the two `.cpp` files are concatenated into one translation unit, so the definitions collide and the editor module fails to compile:

```
error C2084: function '...SegmentToJson(const FAnimSegment &)' already has a body
```

## Fix
Prefix each helper per file — `MontageInspectSegmentToJson` / `MontageSlotSegmentToJson` — matching the `MontageInspectSchemaProperty` / `MontageSlotSchemaProperty` convention already used in these files. The two implementations differ (inspect emits `end_pos`/`valid`; slot omits them), so they are intentionally not merged.

## Verification
Clean editor builds on **UE 5.7** (`FantasyMakerVREditor`) and **UE 5.8** (`StarKnightsEditor`) — `SoftUEBridgeEditor` compiles and links, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)