### PR TITLE
Fix SoftUEBridge for UE 5.8 FJsonObject FSharedString keys

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridge/Private/Protocol/BridgeTypes.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridge/Private/Protocol/BridgeTypes.cpp
@@ -35,16 +35,16 @@ TOptional<FBridgeRequest> FBridgeRequest::FromJsonString(const FString& JsonStri
 	Root->TryGetStringField(TEXT("jsonrpc"), Req.JsonRpc);
 
 	// ID can be string or number; store as string
-	const TSharedPtr<FJsonValue>* IdField = Root->Values.Find(TEXT("id"));
-	if (IdField && IdField->IsValid())
+	TSharedPtr<FJsonValue> IdField = Root->TryGetField(TEXT("id"));
+	if (IdField.IsValid())
 	{
-		if ((*IdField)->Type == EJson::String)
+		if (IdField->Type == EJson::String)
 		{
-			Req.Id = (*IdField)->AsString();
+			Req.Id = IdField->AsString();
 		}
-		else if ((*IdField)->Type == EJson::Number)
+		else if (IdField->Type == EJson::Number)
 		{
-			Req.Id = FString::Printf(TEXT("%g"), (*IdField)->AsNumber());
+			Req.Id = FString::Printf(TEXT("%g"), IdField->AsNumber());
 		}
 	}
 

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridge/Private/Tools/CallFunctionTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridge/Private/Tools/CallFunctionTool.cpp
@@ -223,11 +223,11 @@ namespace
 
 			if (FuncArgs.IsValid())
 			{
-				const TSharedPtr<FJsonValue>* ArgValue = FuncArgs->Values.Find(Prop->GetName());
-				if (ArgValue && ArgValue->IsValid())
+				TSharedPtr<FJsonValue> ArgValue = FuncArgs->TryGetField(Prop->GetName());
+				if (ArgValue.IsValid())
 				{
 					FString ImportText;
-					if (JsonValueToImportText(*ArgValue, ImportText) && !ImportText.IsEmpty())
+					if (JsonValueToImportText(ArgValue, ImportText) && !ImportText.IsEmpty())
 					{
 						Prop->ImportText_Direct(*ImportText, ParamPtr, TargetObject, PPF_None);
 					}

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimBoneReferenceUtils.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimBoneReferenceUtils.cpp
@@ -278,9 +278,9 @@ bool LoadBoneMap(
 	}
 
 	OutBoneMapJson = MakeShared<FJsonObject>();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*BoneMapObject)->Values)
+	for (const auto& Pair : (*BoneMapObject)->Values)
 	{
-		const FString OldName = Pair.Key.TrimStartAndEnd();
+		const FString OldName = FString(*Pair.Key).TrimStartAndEnd();
 		const FString NewName = Pair.Value.IsValid() ? Pair.Value->AsString().TrimStartAndEnd() : TEXT("");
 		if (OldName.IsEmpty() || NewName.IsEmpty())
 		{

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimRepointReferencesTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Animation/AnimRepointReferencesTool.cpp
@@ -57,9 +57,9 @@ bool LoadReplacementMap(
 	}
 
 	OutReplacementPaths = MakeShared<FJsonObject>();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*ReplacementObject)->Values)
+	for (const auto& Pair : (*ReplacementObject)->Values)
 	{
-		const FString OldPath = Pair.Key;
+		const FString OldPath(*Pair.Key);
 		const FString NewPath = Pair.Value.IsValid() ? Pair.Value->AsString() : TEXT("");
 		if (OldPath.IsEmpty() || NewPath.IsEmpty())
 		{

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/AssetReferenceRepointUtils.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/AssetReferenceRepointUtils.cpp
@@ -410,9 +410,9 @@ bool LoadReplacementMap(
 	}
 
 	OutReplacementMap.ReplacementPaths = MakeShared<FJsonObject>();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*ReplacementObject)->Values)
+	for (const auto& Pair : (*ReplacementObject)->Values)
 	{
-		const FString OldPath = Pair.Key.TrimStartAndEnd();
+		const FString OldPath = FString(*Pair.Key).TrimStartAndEnd();
 		const FString NewPath = Pair.Value.IsValid() ? Pair.Value->AsString().TrimStartAndEnd() : TEXT("");
 		if (OldPath.IsEmpty() || NewPath.IsEmpty())
 		{

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
@@ -316,9 +316,9 @@ namespace
 			FProperty* Property = nullptr;
 			void* Container = nullptr;
 			FString FindError;
-			if (!FBridgeAssetModifier::FindPropertyByPath(Node, Pair.Key, Property, Container, FindError))
+			if (!FBridgeAssetModifier::FindPropertyByPath(Node, FString(*Pair.Key), Property, Container, FindError))
 			{
-				MissingPropertyNames.Add(Pair.Key);
+				MissingPropertyNames.Add(FString(*Pair.Key));
 				Errors.Add(FString::Printf(TEXT("Property not found: %s"), *Pair.Key));
 				continue;
 			}
@@ -346,29 +346,29 @@ namespace
 				continue;
 			}
 
-			const TSharedPtr<FJsonValue>* ValuePtr = Properties->Values.Find(PropertyName);
-			if (!ValuePtr || !ValuePtr->IsValid())
+			TSharedPtr<FJsonValue> ValuePtr = Properties->TryGetField(PropertyName);
+			if (!ValuePtr.IsValid())
 			{
 				continue;
 			}
 
-			if (TryApplyObjectPinDefault(Pin, *ValuePtr))
+			if (TryApplyObjectPinDefault(Pin, ValuePtr))
 			{
 				ResolvedByPin.Add(PropertyName);
 			}
-			else if ((*ValuePtr)->Type == EJson::Number)
+			else if (ValuePtr->Type == EJson::Number)
 			{
-				Pin->DefaultValue = FString::Printf(TEXT("%g"), (*ValuePtr)->AsNumber());
+				Pin->DefaultValue = FString::Printf(TEXT("%g"), ValuePtr->AsNumber());
 				ResolvedByPin.Add(PropertyName);
 			}
-			else if ((*ValuePtr)->Type == EJson::Boolean)
+			else if (ValuePtr->Type == EJson::Boolean)
 			{
-				Pin->DefaultValue = (*ValuePtr)->AsBool() ? TEXT("true") : TEXT("false");
+				Pin->DefaultValue = ValuePtr->AsBool() ? TEXT("true") : TEXT("false");
 				ResolvedByPin.Add(PropertyName);
 			}
-			else if ((*ValuePtr)->Type == EJson::String)
+			else if (ValuePtr->Type == EJson::String)
 			{
-				Pin->DefaultValue = (*ValuePtr)->AsString();
+				Pin->DefaultValue = ValuePtr->AsString();
 				ResolvedByPin.Add(PropertyName);
 			}
 			else

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
@@ -688,8 +688,8 @@ namespace
 
 		for (const TCHAR* PropertyName : {TEXT("SkeletalMesh"), TEXT("StaticMesh")})
 		{
-			const TSharedPtr<FJsonValue>* Value = Properties->Values.Find(PropertyName);
-			if (!Value || !Value->IsValid())
+			TSharedPtr<FJsonValue> Value = Properties->TryGetField(PropertyName);
+			if (!Value.IsValid())
 			{
 				continue;
 			}
@@ -703,7 +703,7 @@ namespace
 			}
 
 			FString ObjectPath;
-			if (!TryGetAssetPathFromJsonValue(*Value, ObjectPath))
+			if (!TryGetAssetPathFromJsonValue(Value, ObjectPath))
 			{
 				continue;
 			}
@@ -779,11 +779,11 @@ namespace
 			return false;
 		}
 
-		const TSharedPtr<FJsonValue>* GridValue = Arguments->Values.Find(TEXT("grid_size"));
-		if (GridValue && GridValue->IsValid())
+		TSharedPtr<FJsonValue> GridValue = Arguments->TryGetField(TEXT("grid_size"));
+		if (GridValue.IsValid())
 		{
 			FIntPoint GridSize;
-			if (!ReadIntPointValue(*GridValue, GridSize, OutError))
+			if (!ReadIntPointValue(GridValue, GridSize, OutError))
 			{
 				return false;
 			}
@@ -793,11 +793,11 @@ namespace
 			}
 		}
 
-		const TSharedPtr<FJsonValue>* MaxGridValue = Arguments->Values.Find(TEXT("max_grid_size"));
-		if (MaxGridValue && MaxGridValue->IsValid())
+		TSharedPtr<FJsonValue> MaxGridValue = Arguments->TryGetField(TEXT("max_grid_size"));
+		if (MaxGridValue.IsValid())
 		{
 			FIntPoint MaxGridSize;
-			if (!ReadIntPointValue(*MaxGridValue, MaxGridSize, OutError))
+			if (!ReadIntPointValue(MaxGridValue, MaxGridSize, OutError))
 			{
 				return false;
 			}
@@ -836,27 +836,27 @@ namespace
 				return false;
 			}
 
-			const TSharedPtr<FJsonValue>* MinValue = (*BlockObject)->Values.Find(TEXT("min"));
-			const TSharedPtr<FJsonValue>* MaxValue = (*BlockObject)->Values.Find(TEXT("max"));
-			const TSharedPtr<FJsonValue>* SizeValue = (*BlockObject)->Values.Find(TEXT("size"));
+			TSharedPtr<FJsonValue> MinValue = (*BlockObject)->TryGetField(TEXT("min"));
+			TSharedPtr<FJsonValue> MaxValue = (*BlockObject)->TryGetField(TEXT("max"));
+			TSharedPtr<FJsonValue> SizeValue = (*BlockObject)->TryGetField(TEXT("size"));
 			FIntPoint Min;
 			FIntPoint Max;
-			if (!MinValue || !ReadIntPointValue(*MinValue, Min, OutError))
+			if (!MinValue.IsValid() || !ReadIntPointValue(MinValue, Min, OutError))
 			{
 				OutError = TEXT("Each block requires min as [x,y] or {x,y}");
 				return false;
 			}
-			if (MaxValue)
+			if (MaxValue.IsValid())
 			{
-				if (!ReadIntPointValue(*MaxValue, Max, OutError))
+				if (!ReadIntPointValue(MaxValue, Max, OutError))
 				{
 					return false;
 				}
 			}
-			else if (SizeValue)
+			else if (SizeValue.IsValid())
 			{
 				FIntPoint Size;
-				if (!ReadIntPointValue(*SizeValue, Size, OutError))
+				if (!ReadIntPointValue(SizeValue, Size, OutError))
 				{
 					return false;
 				}

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/MutableIntrospectionUtils.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/MutableIntrospectionUtils.cpp
@@ -962,12 +962,12 @@ namespace
 
 		for (const TCHAR* FieldName : FieldNames)
 		{
-			const TSharedPtr<FJsonValue>* FieldValue = Object->Values.Find(FieldName);
+			TSharedPtr<FJsonValue> FieldValue = Object->TryGetField(FieldName);
 			if (!FieldValue)
 			{
 				continue;
 			}
-			CollectStringsFromJsonValue(*FieldValue, Values);
+			CollectStringsFromJsonValue(FieldValue, Values);
 		}
 		return Values;
 	}
@@ -1290,10 +1290,10 @@ TSharedPtr<FJsonObject> MutableIntrospectionUtils::BuildMutableDiagnosticsResult
 	TSharedPtr<FJsonObject> AssetSignals = Context.bAssetLoaded
 		? CollectInterestingObjectProperties(Context.AssetObject, false)
 		: MakeShared<FJsonObject>();
-	for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : AssetSignals->Values)
+	for (const auto& Pair : AssetSignals->Values)
 	{
 		TSharedPtr<FJsonObject> SignalJson = MakeShared<FJsonObject>();
-		SignalJson->SetStringField(TEXT("property"), Pair.Key);
+		SignalJson->SetStringField(TEXT("property"), *Pair.Key);
 		SignalJson->SetStringField(TEXT("value"), JsonValueToFlatString(Pair.Value));
 		SignalJson->SetStringField(TEXT("owner"), Context.bAssetLoaded ? Context.AssetObject->GetPathName() : Context.AssetPath);
 		Signals.Add(MakeShared<FJsonValueObject>(SignalJson));
@@ -1315,7 +1315,7 @@ TSharedPtr<FJsonObject> MutableIntrospectionUtils::BuildMutableDiagnosticsResult
 			: MakeCapability(TEXT("unknown"), TEXT("No projector support signal could be derived without Mutable-specific runtime APIs.")));
 	Capabilities->SetObjectField(
 		TEXT("clothing_enablement"),
-		AssetSignals->Values.Contains(TEXT("Cloth")) || AssetSignals->Values.Contains(TEXT("Clothing"))
+		AssetSignals->HasField(TEXT("Cloth")) || AssetSignals->HasField(TEXT("Clothing"))
 			? MakeCapability(TEXT("detected"), TEXT("Found cloth-related reflected properties on the asset."))
 			: MakeCapability(TEXT("unknown"), TEXT("No cloth-related reflected properties were detected.")));
 	Capabilities->SetObjectField(

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Editor/CaptureScreenshotTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Editor/CaptureScreenshotTool.cpp
@@ -248,9 +248,9 @@ namespace
 			return;
 		}
 
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : Source->Values)
+		for (const auto& Pair : Source->Values)
 		{
-			Target->SetField(Pair.Key, Pair.Value);
+			Target->SetField(*Pair.Key, Pair.Value);
 		}
 	}
 

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Widget/ApplyWidgetTreeTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Widget/ApplyWidgetTreeTool.cpp
@@ -1082,12 +1082,12 @@ bool UApplyWidgetTreeTool::ApplyWidgetProperties(
 	const TSharedPtr<FJsonObject>* Properties = nullptr;
 	if (NodeSpec->TryGetObjectField(TEXT("properties"), Properties) && Properties && Properties->IsValid())
 	{
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : (*Properties)->Values)
+		for (const auto& Pair : (*Properties)->Values)
 		{
 			FProperty* Property = nullptr;
 			void* Container = nullptr;
 			FString FindError;
-			if (!FBridgeAssetModifier::FindPropertyByPath(Widget, Pair.Key, Property, Container, FindError))
+			if (!FBridgeAssetModifier::FindPropertyByPath(Widget, FString(*Pair.Key), Property, Container, FindError))
 			{
 				OutError = FString::Printf(TEXT("%s.%s: %s"), *Widget->GetName(), *Pair.Key, *FindError);
 				return false;

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/AddDataTableRowTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/AddDataTableRowTool.cpp
@@ -122,12 +122,12 @@ FBridgeToolResult UAddDataTableRowTool::Execute(
 		TArray<FString> FailedFields;
 		TArray<FString> UnknownFields;
 
-		for (const TPair<FString, TSharedPtr<FJsonValue>>& Pair : RowData->Values)
+		for (const auto& Pair : RowData->Values)
 		{
 			FProperty* Property = RowStruct->FindPropertyByName(FName(*Pair.Key));
 			if (!Property)
 			{
-				UnknownFields.Add(Pair.Key);
+				UnknownFields.Add(FString(*Pair.Key));
 				continue;
 			}
 
@@ -138,7 +138,7 @@ FBridgeToolResult UAddDataTableRowTool::Execute(
 				continue;
 			}
 
-			AppliedFields.Add(Pair.Key);
+			AppliedFields.Add(FString(*Pair.Key));
 		}
 
 		if (FailedFields.Num() > 0 || UnknownFields.Num() > 0)
@@ -181,7 +181,10 @@ FBridgeToolResult UAddDataTableRowTool::Execute(
 	if (RowData.IsValid())
 	{
 		TArray<FString> AppliedFields;
-		RowData->Values.GetKeys(AppliedFields);
+		for (const auto& Pair : RowData->Values)
+		{
+			AppliedFields.Add(FString(*Pair.Key));
+		}
 		Result->SetArrayField(TEXT("applied_fields"), ToJsonStringArray(AppliedFields));
 	}
 	Result->SetBoolField(TEXT("needs_save"), true);

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/AddGraphNodeTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/AddGraphNodeTool.cpp
@@ -671,7 +671,7 @@ TArray<FString> UAddGraphNodeTool::ApplyNodeProperties(UObject* Node, const TSha
 
 	for (const auto& Pair : Properties->Values)
 	{
-		const FString& PropertyName = Pair.Key;
+		const FString PropertyName(*Pair.Key);
 		const TSharedPtr<FJsonValue>& Value = Pair.Value;
 
 		// Find the property - first try direct lookup on the node
@@ -742,21 +742,21 @@ TArray<FString> UAddGraphNodeTool::ApplyNodeProperties(UObject* Node, const TSha
 			{
 				if (Pin && Pin->PinName.ToString() == PropName)
 				{
-					const TSharedPtr<FJsonValue>* ValuePtr = Properties->Values.Find(PropName);
-					if (ValuePtr && ValuePtr->IsValid())
+					TSharedPtr<FJsonValue> ValuePtr = Properties->TryGetField(PropName);
+					if (ValuePtr.IsValid())
 					{
 						FString StringValue;
-						if ((*ValuePtr)->Type == EJson::Number)
+						if (ValuePtr->Type == EJson::Number)
 						{
-							StringValue = FString::Printf(TEXT("%g"), (*ValuePtr)->AsNumber());
+							StringValue = FString::Printf(TEXT("%g"), ValuePtr->AsNumber());
 						}
-						else if ((*ValuePtr)->Type == EJson::Boolean)
+						else if (ValuePtr->Type == EJson::Boolean)
 						{
-							StringValue = (*ValuePtr)->AsBool() ? TEXT("true") : TEXT("false");
+							StringValue = ValuePtr->AsBool() ? TEXT("true") : TEXT("false");
 						}
 						else
 						{
-							StringValue = (*ValuePtr)->AsString();
+							StringValue = ValuePtr->AsString();
 						}
 
 						Pin->DefaultValue = StringValue;

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/SetNodePropertyTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/SetNodePropertyTool.cpp
@@ -317,7 +317,7 @@ TArray<FString> USetNodePropertyTool::ApplyProperties(UBlueprint* Blueprint, UOb
 
 	for (const auto& Pair : Properties->Values)
 	{
-		const FString& PropertyName = Pair.Key;
+		const FString PropertyName(*Pair.Key);
 		const TSharedPtr<FJsonValue>& Value = Pair.Value;
 
 		if (ApplyCallFunctionReferenceStringShortcut(Cast<UEdGraphNode>(Node), Blueprint, PropertyName, Value, Errors))
@@ -395,21 +395,21 @@ TArray<FString> USetNodePropertyTool::ApplyProperties(UBlueprint* Blueprint, UOb
 			{
 				if (Pin && Pin->PinName.ToString() == PropName)
 				{
-					const TSharedPtr<FJsonValue>* ValuePtr = Properties->Values.Find(PropName);
-					if (ValuePtr && ValuePtr->IsValid())
+					TSharedPtr<FJsonValue> ValuePtr = Properties->TryGetField(PropName);
+					if (ValuePtr.IsValid())
 					{
 						FString StringValue;
-						if ((*ValuePtr)->Type == EJson::Number)
+						if (ValuePtr->Type == EJson::Number)
 						{
-							StringValue = FString::Printf(TEXT("%g"), (*ValuePtr)->AsNumber());
+							StringValue = FString::Printf(TEXT("%g"), ValuePtr->AsNumber());
 						}
-						else if ((*ValuePtr)->Type == EJson::Boolean)
+						else if (ValuePtr->Type == EJson::Boolean)
 						{
-							StringValue = (*ValuePtr)->AsBool() ? TEXT("true") : TEXT("false");
+							StringValue = ValuePtr->AsBool() ? TEXT("true") : TEXT("false");
 						}
 						else
 						{
-							StringValue = (*ValuePtr)->AsString();
+							StringValue = ValuePtr->AsString();
 						}
 
 						Pin->DefaultValue = StringValue;


### PR DESCRIPTION
## Summary
UE 5.8 changes `FJsonObject::Values` to a map keyed by `FSharedString` (previously `FString`). Any bridge code that touches that map directly no longer compiles under 5.8. This migrates all such sites to key-type-agnostic access.

Two patterns:
- `Obj->Values.Find(TEXT("x"))` (returns `const TSharedPtr<FJsonValue>*`) → `Obj->TryGetField(TEXT("x"))` (returns `TSharedPtr<FJsonValue>` by value), with surrounding null-checks/derefs updated (`!P || !P->IsValid()` → `!P.IsValid()`, `*P` → `P`).
- Iterating `for (const auto& Pair : Obj->Values)` where `Pair.Key` is used as `FString` → `FString(*Pair.Key)`.

Only direct `FJsonObject::Values` access is affected; the accessor methods (`TryGetStringField`, `SetField`, etc.) already convert internally. Includes the `mutable graph set-layout-blocks` tool from cli-v1.39.0.

## Backward compatibility
Both patterns also compile under **UE 5.7** (`*FString` yields `const TCHAR*`; `TryGetField` predates 5.8), so this does not break 5.7 builds.

## Verification
- **UE 5.7** (`FantasyMakerVREditor`): clean build, backward-compat confirmed.
- **UE 5.8** (`StarKnightsEditor`): clean build — `SoftUEBridge`/`SoftUEBridgeEditor` compile and link with 0 errors, exercising the actual `FSharedString` code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)