### PR TITLE
fix(plugin): migrate UE 5.8-deprecated APIs in editor module (5.7-compatible)

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/SoftUEBridgeEditorModule.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/SoftUEBridgeEditorModule.cpp
@@ -309,9 +309,15 @@ void FSoftUEBridgeEditorModule::StartupModule()
 
 	// Newly added editor UCLASS tools may not have valid StaticClass() pointers
 	// at module startup in freshly rebuilt editor sessions.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+	PostEngineInitHandle = FCoreDelegates::GetOnPostEngineInit().AddRaw(
+		this,
+		&FSoftUEBridgeEditorModule::RegisterAnimationTools);
+#else
 	PostEngineInitHandle = FCoreDelegates::OnPostEngineInit.AddRaw(
 		this,
 		&FSoftUEBridgeEditorModule::RegisterAnimationTools);
+#endif
 	DeferredAnimationRegistrationHandle = FTSTicker::GetCoreTicker().AddTicker(
 		FTickerDelegate::CreateRaw(this, &FSoftUEBridgeEditorModule::RegisterAnimationToolsOnTicker));
 
@@ -357,7 +363,11 @@ void FSoftUEBridgeEditorModule::ShutdownModule()
 {
 	if (PostEngineInitHandle.IsValid())
 	{
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+		FCoreDelegates::GetOnPostEngineInit().Remove(PostEngineInitHandle);
+#else
 		FCoreDelegates::OnPostEngineInit.Remove(PostEngineInitHandle);
+#endif
 		PostEngineInitHandle.Reset();
 	}
 	if (DeferredAnimationRegistrationHandle.IsValid())

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/EditCustomizableObjectGraphTool.cpp
@@ -65,7 +65,11 @@ namespace
 		}
 
 		TArray<UObject*> InnerObjects;
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+		GetObjectsWithOuter(AssetObject, InnerObjects, EGetObjectsFlags::IncludeNestedObjects);
+#else
 		GetObjectsWithOuter(AssetObject, InnerObjects, true);
+#endif
 		for (UObject* InnerObject : InnerObjects)
 		{
 			if (UEdGraph* Graph = Cast<UEdGraph>(InnerObject))

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/MutableIntrospectionUtils.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/MutableIntrospectionUtils.cpp
@@ -715,7 +715,11 @@ namespace
 		}
 
 		TArray<UObject*> InnerObjects;
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+		GetObjectsWithOuter(AssetObject, InnerObjects, EGetObjectsFlags::IncludeNestedObjects);
+#else
 		GetObjectsWithOuter(AssetObject, InnerObjects, true);
+#endif
 		for (UObject* InnerObject : InnerObjects)
 		{
 			if (UEdGraph* Graph = Cast<UEdGraph>(InnerObject))

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Rewind/RewindHelper.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Rewind/RewindHelper.cpp
@@ -709,7 +709,7 @@ bool FRewindHelper::HasData()
 		{
 			return true;
 		}
-		if (Debugger->IsRecording() || Debugger->IsTraceFileLoaded())
+		if (Debugger->IsRecording())
 		{
 			return true;
 		}

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Widget/WireWidgetNavigationTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Widget/WireWidgetNavigationTool.cpp
@@ -93,7 +93,7 @@ FBridgeToolResult UWireWidgetNavigationTool::Execute(
 		return FBridgeToolResult::Error(TEXT("wire-widget-navigation blocked_active_pie editor_state=pie_active: PIE is active; stop PIE before mutating WidgetBlueprint assets, or pass allow_pie=true / --allow-pie to override."));
 	}
 	const bool bAllowBusy = GetBoolArgOrDefault(Arguments, TEXT("allow_busy"), false);
-	if (!bAllowBusy && (GIsSavingPackage || IsGarbageCollecting()))
+	if (!bAllowBusy && (UE::IsSavingPackage() || IsGarbageCollecting()))
 	{
 		return FBridgeToolResult::Error(TEXT("wire-widget-navigation blocked_editor_busy editor_state=busy: the editor is saving or garbage collecting; retry after the editor is idle, or pass allow_busy=true / --allow-busy to override."));
 	}

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/SetNodePositionTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Write/SetNodePositionTool.cpp
@@ -46,7 +46,11 @@ namespace
 		}
 
 		TArray<UObject*> InnerObjects;
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+		GetObjectsWithOuter(AssetObject, InnerObjects, EGetObjectsFlags::IncludeNestedObjects);
+#else
 		GetObjectsWithOuter(AssetObject, InnerObjects, true);
+#endif
 		for (UObject* InnerObject : InnerObjects)
 		{
 			if (UEdGraph* Graph = Cast<UEdGraph>(InnerObject))

--- a/tests/test_plugin_descriptor.py
+++ b/tests/test_plugin_descriptor.py
@@ -1072,7 +1072,7 @@ def test_umg_workflow_tools_are_explicitly_registered_and_support_runtime_contra
         "bindings",
         "allow_pie",
         "allow_busy",
-        "GIsSavingPackage",
+        "IsSavingPackage",
         "IsGarbageCollecting",
         "IsPlaySessionInProgress",
         "editor_state",


### PR DESCRIPTION
## Summary
Resolves the C4996 deprecation warnings emitted when building `SoftUEBridgeEditor` against **UE 5.8**, while keeping the module buildable on **UE 5.7**. Two of the replacement APIs (`GetOnPostEngineInit()`, `EGetObjectsFlags`) were introduced in 5.8 and do not exist in 5.7, so they are guarded on engine version (matching the existing `ENGINE_MAJOR_VERSION`/`ENGINE_MINOR_VERSION` convention in `WidgetBlueprintTool.cpp`).

| Deprecated API | 5.8+ | 5.7 fallback |
|---|---|---|
| `FCoreDelegates::OnPostEngineInit` (×2) | `GetOnPostEngineInit()` | member access (guarded) |
| `GetObjectsWithOuter(..., bool)` (×3) | `EGetObjectsFlags::IncludeNestedObjects` | bool overload (guarded) |
| `GIsSavingPackage` | `UE::IsSavingPackage()` | same (valid on both, no guard) |
| `IRewindDebugger::IsTraceFileLoaded()` | removed (5.8 no-op stub) | removed |

`IsTraceFileLoaded()`'s loaded-from-file state is already tracked by `RewindHelper`'s own `bLoadedFromFile` flag, so the dead `||` term is dropped.

## Verification
Clean builds with **0 errors and 0 C4996 warnings** on **both** `FantasyMakerVREditor` (UE 5.7) and `StarKnightsEditor` (UE 5.8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)