### PR TITLE
fix(cli): content KeyError guard and stray testimonial backslash

### DIFF
--- a/soft_ue_cli/client.py
+++ b/soft_ue_cli/client.py
@@ -179,7 +179,7 @@ def call_tool(tool_name: str, arguments: dict[str, Any], timeout: float | None =
     # Parse text content as JSON when possible
     content = result.get("content", [])
     if content and content[0].get("type") == "text":
-        text = content[0]["text"]
+        text = content[0].get("text", "")
         try:
             return json.loads(text)
         except json.JSONDecodeError:

--- a/soft_ue_cli/testimonial.py
+++ b/soft_ue_cli/testimonial.py
@@ -41,7 +41,7 @@ def _build_issue_body(
 ) -> str:
     """Build the markdown body for the GitHub Issue."""
     attribution = agent_name or "Anonymous"
-    sections = [f"> {message}\n\n\\— {attribution}"]
+    sections = [f"> {message}\n\n— {attribution}"]
 
     meta_lines = [f"- CLI version: {cli_version}", f"- Streak: {streak} days"]
     if rating is not None:


### PR DESCRIPTION
## Summary
Two small CLI fixes:

1. **`client.py`** — `content[0]["text"]` → `content[0].get("text", "")`. Avoids a `KeyError` when a text-type content element lacks a `text` key.
2. **`testimonial.py`** — remove the stray backslash before the em-dash so the generated GitHub issue attribution renders `— name` instead of `\— name`.

## Verification
Full test suite green (527 passed, 3 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)