### PR TITLE
fix(plugin): restore UE 5.7 compat for cloth dataflow and unbind APIs

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp
@@ -193,6 +193,37 @@ bool SaveMeshIfRequested(USkeletalMesh* Mesh, bool bSave, TSharedPtr<FJsonObject
 	return true;
 }
 
+// UChaosClothAssetBase::HasDataflow() was only added in UE 5.8. It is defined
+// there as GetDataflow() != nullptr, and GetDataflow() already exists in 5.7,
+// so this spelling is correct on both versions with no version guard needed.
+bool ClothAssetHasDataflow(const UChaosClothAsset* Asset)
+{
+	return Asset && Asset->GetDataflow() != nullptr;
+}
+
+// UE 5.8 added the per-section overload UnbindFromSkeletalMesh(Mesh, Lod, Section)
+// and deprecated the LOD-only one; UE 5.7 only has the LOD-only overload.
+void UnbindClothFromSkeletalMesh(
+	UClothingAssetBase* Asset,
+	USkeletalMesh* Mesh,
+	int32 LodIndex,
+	int32 SectionIndex)
+{
+	if (!Asset || !Mesh)
+	{
+		return;
+	}
+
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+	Asset->UnbindFromSkeletalMesh(Mesh, LodIndex, SectionIndex);
+#else
+	// 5.7 cannot unbind a single section. SectionIndex == INDEX_NONE already means
+	// "all sections of this LOD", so those call sites are exactly equivalent; a
+	// specific SectionIndex necessarily unbinds the whole LOD on 5.7.
+	Asset->UnbindFromSkeletalMesh(Mesh, LodIndex);
+#endif
+}
+
 void ClearOriginalSectionClothData(FSkelMeshSourceSectionUserData& OriginalSectionData)
 {
 	OriginalSectionData.CorrespondClothAssetIndex = INDEX_NONE;
@@ -237,14 +268,14 @@ bool BindClothAssetToSection(
 	if (UClothingAssetBase* CurrentAsset = Mesh->GetSectionClothingAsset(LodIndex, SectionIndex))
 	{
 		CurrentAsset->Modify();
-		CurrentAsset->UnbindFromSkeletalMesh(Mesh, LodIndex, SectionIndex);
+		UnbindClothFromSkeletalMesh(CurrentAsset, Mesh, LodIndex, SectionIndex);
 	}
 
 	Asset->Modify();
 	// Repair assets left with a populated LodMap but no section binding by older bridge versions.
 	if (bClearExistingAssetBindings)
 	{
-		Asset->UnbindFromSkeletalMesh(Mesh, LodIndex, INDEX_NONE);
+		UnbindClothFromSkeletalMesh(Asset, Mesh, LodIndex, INDEX_NONE);
 	}
 
 	FSkelMeshSection& Section = Mesh->GetImportedModel()->LODModels[LodIndex].Sections[SectionIndex];
@@ -975,7 +1006,7 @@ bool ValidateConvertedChaosClothAsset(UChaosClothAsset* Asset, FString& OutError
 		return false;
 	}
 
-	if (Asset->HasDataflow() || Asset->HasValidClothSimulationModels() || HasChaosClothCollectionData(Asset))
+	if (ClothAssetHasDataflow(Asset) || Asset->HasValidClothSimulationModels() || HasChaosClothCollectionData(Asset))
 	{
 		return true;
 	}
@@ -2831,8 +2862,9 @@ FBridgeToolResult UClothConvertTool::Execute(const TSharedPtr<FJsonObject>& Argu
 
 	TSharedPtr<FJsonObject> Result = ChaosClothAssetToJson(NewAsset, OutputAssetPath, false);
 	Result->SetBoolField(TEXT("converted"), true);
-	Result->SetBoolField(TEXT("dataflow_based"), NewAsset->HasDataflow());
-	Result->SetStringField(TEXT("conversion_mode"), NewAsset->HasDataflow() ? TEXT("dataflow") : TEXT("legacy_collection"));
+	const bool bNewAssetHasDataflow = ClothAssetHasDataflow(NewAsset);
+	Result->SetBoolField(TEXT("dataflow_based"), bNewAssetHasDataflow);
+	Result->SetStringField(TEXT("conversion_mode"), bNewAssetHasDataflow ? TEXT("dataflow") : TEXT("legacy_collection"));
 	Result->SetStringField(TEXT("skeletal_mesh"), SkeletalMeshPath);
 	Result->SetStringField(TEXT("source_asset_name"), SourceAsset->GetName());
 	Result->SetStringField(TEXT("output_asset"), OutputAssetPath);

--- a/tests/test_plugin_descriptor.py
+++ b/tests/test_plugin_descriptor.py
@@ -910,7 +910,11 @@ def test_cloth_bind_persists_original_section_user_data_and_repairs_stale_lod_ma
 
     assert "BindClothAssetToSection" in source
     assert "FScopedSkeletalMeshPostEditChange BindingPostEditChange(Mesh)" in source
-    assert "Asset->UnbindFromSkeletalMesh(Mesh, LodIndex, INDEX_NONE)" in source
+    # Routed through a compat helper: the 3-arg per-section overload is UE 5.8+,
+    # while 5.7 only has the LOD-wide one. INDEX_NONE means "all sections of the
+    # LOD", which is what both engine versions do here.
+    assert "UnbindClothFromSkeletalMesh(Asset, Mesh, LodIndex, INDEX_NONE)" in source
+    assert "void UnbindClothFromSkeletalMesh(" in source
     assert "UserSectionsData.FindOrAdd" in source
     assert "OriginalSectionData.CorrespondClothAssetIndex" in source
     assert "OriginalSectionData.ClothingData.AssetGuid" in source

--- a/tests/test_plugin_source_compat.py
+++ b/tests/test_plugin_source_compat.py
@@ -83,6 +83,29 @@ def test_editor_tools_avoid_ue58_deprecated_object_and_package_apis():
     assert "GIsSavingPackage" not in wire_source
 
 
+def test_cloth_tools_guard_ue58_only_dataflow_and_unbind_apis():
+    source = _read("SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp")
+
+    # UChaosClothAssetBase::HasDataflow() is UE 5.8+. It is defined there as
+    # GetDataflow() != nullptr, and GetDataflow() exists in 5.7 too, so the
+    # helper needs no version guard - but it must not call HasDataflow directly.
+    assert "bool ClothAssetHasDataflow(" in source
+    assert "Asset->GetDataflow() != nullptr" in source
+    assert "->HasDataflow()" not in source
+
+    # The per-section UnbindFromSkeletalMesh overload is UE 5.8+; 5.7 only has
+    # the LOD-wide one, so this call genuinely needs a version guard.
+    assert "void UnbindClothFromSkeletalMesh(" in source
+    assert "ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8" in source
+    unbind_block = source.split("void UnbindClothFromSkeletalMesh(", 1)[1].split("\n}", 1)[0]
+    assert "Asset->UnbindFromSkeletalMesh(Mesh, LodIndex, SectionIndex)" in unbind_block
+    assert "Asset->UnbindFromSkeletalMesh(Mesh, LodIndex)" in unbind_block
+
+    # Every call site must route through the helper, so the only two raw calls
+    # to the engine API are the two guarded ones inside it.
+    assert source.count("->UnbindFromSkeletalMesh(") == 2
+
+
 def test_rewind_helper_avoids_removed_trace_file_loaded_check():
     source = _read("SoftUEBridgeEditor/Private/Tools/Rewind/RewindHelper.cpp")
 


### PR DESCRIPTION
## Problem

cli-v1.45.0 uses two UE 5.8-only cloth APIs without version guards, so `SoftUEBridgeEditor` no longer compiles against UE 5.7:

```
ClothTools.cpp(978,13):  error C2039: 'HasDataflow': is not a member of 'UChaosClothAsset'
ClothTools.cpp(2834,57): error C2039: 'HasDataflow': is not a member of 'UChaosClothAsset'
ClothTools.cpp(2835,60): error C2039: 'HasDataflow': is not a member of 'UChaosClothAsset'
ClothTools.cpp(240,17):  error C2661: 'UClothingAssetBase::UnbindFromSkeletalMesh': no overloaded function takes 3 arguments
ClothTools.cpp(247,10):  error C2661: 'UClothingAssetBase::UnbindFromSkeletalMesh': no overloaded function takes 3 arguments
```

(The accompanying `SetBoolField`/`SetStringField` "no overloaded function takes 1 arguments" errors are cascades from the failed `HasDataflow()` calls.)

## Fix

Both calls are routed through small helpers, keeping the 5.8 behaviour exactly as-is.

**`HasDataflow()`** — added in 5.8, replacing the now-deprecated `bHasDataflowAsset`. 5.8 defines it as:

```cpp
bool HasDataflow() const { return GetDataflow() != nullptr; }
```

`GetDataflow()` is public on `UChaosClothAssetBase` in 5.7 as well, so `ClothAssetHasDataflow()` uses that spelling and needs **no** `#if` — it is the same expression on both versions. (`bHasDataflowAsset` is not usable directly: it is `protected` and `WITH_EDITORONLY_DATA`-only in 5.7.)

**`UnbindFromSkeletalMesh(Mesh, Lod, Section)`** — the per-section overload is 5.8-only; 5.7 has only the LOD-wide one, so this genuinely needs a guard. Note that 5.8's own deprecated 2-arg overload forwards as `UnbindFromSkeletalMesh(InSkelMesh, InMeshLodIndex, INDEX_NONE)`, and `SectionIndex == INDEX_NONE` is documented as "unbind all sections of the specified LOD" — so the `INDEX_NONE` call site is *exactly* equivalent on both versions. The other call site passes a specific section, which 5.7 cannot express; there it unbinds the whole LOD, which is the closest available behaviour and is called out in a comment.

The guard uses `ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)` so it stays correct past UE 5.

## Verification

- **UE 5.7** (`FantasyMakerVREditor`): `Result: Succeeded`, 0 errors, with `Module.SoftUEBridgeEditor` compiled and `UnrealEditor-SoftUEBridgeEditor.dll` linked. Previously failed with the errors above.
- **UE 5.8** (`StarKnightsEditor`, clean rebuild): `Result: Succeeded`, 0 errors — 5.8 behaviour unchanged.
- `python -m pytest tests/` — 735 passed, 3 skipped.

`test_cloth_bind_persists_original_section_user_data_and_repairs_stale_lod_map` asserted the raw 3-arg call, so it is updated to the helper call; a new `test_cloth_tools_guard_ue58_only_dataflow_and_unbind_apis` covers both guards so the 5.7 path cannot regress silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)