### PR TITLE
fix(plugin): resolve LoadSkeletalMesh unity-build collision

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/SkeletalMeshSocketTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Asset/SkeletalMeshSocketTool.cpp
@@ -72,7 +72,7 @@ TArray<TSharedPtr<FJsonValue>> RotatorToJsonArray(const FRotator& Value)
 	return Result;
 }
 
-USkeletalMesh* LoadSkeletalMesh(const FString& AssetPath, FString& OutError)
+USkeletalMesh* SocketToolLoadSkeletalMesh(const FString& AssetPath, FString& OutError)
 {
 	USkeletalMesh* Mesh = FBridgeAssetModifier::LoadAssetByPath<USkeletalMesh>(AssetPath, OutError);
 	if (!Mesh)
@@ -186,7 +186,7 @@ FBridgeToolResult USkeletalMeshSocketCreateTool::Execute(
 	}
 
 	FString Error;
-	USkeletalMesh* Mesh = LoadSkeletalMesh(AssetPath, Error);
+	USkeletalMesh* Mesh = SocketToolLoadSkeletalMesh(AssetPath, Error);
 	if (!Mesh)
 	{
 		return FBridgeToolResult::Error(Error);
@@ -295,7 +295,7 @@ FBridgeToolResult USkeletalMeshSocketRemoveTool::Execute(
 	}
 
 	FString Error;
-	USkeletalMesh* Mesh = LoadSkeletalMesh(AssetPath, Error);
+	USkeletalMesh* Mesh = SocketToolLoadSkeletalMesh(AssetPath, Error);
 	if (!Mesh)
 	{
 		return FBridgeToolResult::Error(Error);

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp
@@ -65,7 +65,7 @@ FBridgeSchemaProperty ClothSchemaProperty(
 	return Property;
 }
 
-USkeletalMesh* LoadSkeletalMesh(const FString& AssetPath, FString& OutError)
+USkeletalMesh* ClothLoadSkeletalMesh(const FString& AssetPath, FString& OutError)
 {
 	return FBridgeAssetModifier::LoadAssetByPath<USkeletalMesh>(AssetPath, OutError);
 }
@@ -2622,7 +2622,7 @@ FBridgeToolResult LoadMeshAndAsset(
 	}
 
 	FString LoadError;
-	OutMesh = LoadSkeletalMesh(OutSkeletalMeshPath, LoadError);
+	OutMesh = ClothLoadSkeletalMesh(OutSkeletalMeshPath, LoadError);
 	if (!OutMesh)
 	{
 		return FBridgeToolResult::Error(LoadError);
@@ -2668,7 +2668,7 @@ FBridgeToolResult UClothQueryTool::Execute(const TSharedPtr<FJsonObject>& Argume
 	}
 
 	FString LoadError;
-	USkeletalMesh* Mesh = LoadSkeletalMesh(SkeletalMeshPath, LoadError);
+	USkeletalMesh* Mesh = ClothLoadSkeletalMesh(SkeletalMeshPath, LoadError);
 	if (!Mesh)
 	{
 		return FBridgeToolResult::Error(LoadError);
@@ -2772,7 +2772,7 @@ FBridgeToolResult UClothConvertTool::Execute(const TSharedPtr<FJsonObject>& Argu
 	}
 
 	FString LoadError;
-	USkeletalMesh* Mesh = LoadSkeletalMesh(SkeletalMeshPath, LoadError);
+	USkeletalMesh* Mesh = ClothLoadSkeletalMesh(SkeletalMeshPath, LoadError);
 	if (!Mesh)
 	{
 		return FBridgeToolResult::Error(LoadError);
@@ -3259,7 +3259,7 @@ FBridgeToolResult UClothCreateTool::Execute(const TSharedPtr<FJsonObject>& Argum
 	}
 
 	FString LoadError;
-	USkeletalMesh* Mesh = LoadSkeletalMesh(SkeletalMeshPath, LoadError);
+	USkeletalMesh* Mesh = ClothLoadSkeletalMesh(SkeletalMeshPath, LoadError);
 	if (!Mesh)
 	{
 		return FBridgeToolResult::Error(LoadError);

--- a/tests/test_plugin_source_compat.py
+++ b/tests/test_plugin_source_compat.py
@@ -83,6 +83,19 @@ def test_editor_tools_avoid_ue58_deprecated_object_and_package_apis():
     assert "GIsSavingPackage" not in wire_source
 
 
+def test_skeletal_mesh_loaders_are_unique_for_unity_builds():
+    cloth_source = _read("SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp")
+    socket_source = _read("SoftUEBridgeEditor/Private/Tools/Asset/SkeletalMeshSocketTool.cpp")
+
+    # Both files defined LoadSkeletalMesh in an anonymous namespace. Anonymous
+    # namespaces do not isolate translation units under a unity build - both
+    # files land in one .cpp and the second definition is a redefinition error.
+    assert "USkeletalMesh* LoadSkeletalMesh(" not in cloth_source
+    assert "USkeletalMesh* LoadSkeletalMesh(" not in socket_source
+    assert "ClothLoadSkeletalMesh" in cloth_source
+    assert "SocketToolLoadSkeletalMesh" in socket_source
+
+
 def test_rewind_helper_avoids_removed_trace_file_loaded_check():
     source = _read("SoftUEBridgeEditor/Private/Tools/Rewind/RewindHelper.cpp")
 


### PR DESCRIPTION
## Problem

`ClothTools.cpp` and `SkeletalMeshSocketTool.cpp` both define `LoadSkeletalMesh` in an anonymous namespace:

- `SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp:68`
- `SoftUEBridgeEditor/Private/Tools/Asset/SkeletalMeshSocketTool.cpp:75`

An anonymous namespace gives internal linkage *per translation unit*, but a unity build concatenates both `.cpp` files into one TU — so the two anonymous namespaces merge and the second definition is a redefinition:

```
ClothTools.cpp(68,16):   error C2084: function 'USkeletalMesh *`anonymous-namespace'::LoadSkeletalMesh(const FString &,FString &)' already has a body
ClothTools.cpp(2656,12): error C2264: '`anonymous-namespace'::LoadSkeletalMesh': error in function definition or declaration; function not called
ClothTools.cpp(2702,24): error C2264: ...
ClothTools.cpp(2806,24): error C2264: ...
ClothTools.cpp(3294,24): error C2264: ...
```

### Why this hasn't shown up in normal iteration

It only reproduces on a **clean/full** build. Incremental builds use adaptive non-unity, which compiles a just-touched `.cpp` standalone — so editing either file and rebuilding keeps them in separate TUs and the collision stays hidden. I hit it on a from-scratch editor build.

## Fix

Renamed each to a file-specific name, matching the `MontageInspectSegmentToJson` / `MontageSlotSegmentToJson` precedent from #296:

- `ClothTools.cpp` → `ClothLoadSkeletalMesh`
- `SkeletalMeshSocketTool.cpp` → `SocketToolLoadSkeletalMesh`

Rename only — no behaviour change.

I also swept the rest of the plugin for the same hazard. The other cross-file name matches are all benign: they are either class members, nested inside *distinct named* namespaces (e.g. `SoftUE::AnimBoneReferenceUtils` vs `SoftUE::AssetReferenceRepointUtils`), or in different modules (unity is per-module). `LoadSkeletalMesh` was the only genuine collision.

## Verification

- **UE 5.8** (`StarKnightsEditor`, forced clean rebuild — `Binaries`/`Intermediate` + `Makefile.bin` + `.target` removed so everything is back in unity blobs): `Result: Succeeded`, 0 errors, with `Module.SoftUEBridgeEditor` compiled and `UnrealEditor-SoftUEBridgeEditor.dll` linked. Failed with the errors above before this change.
- **UE 5.7** (`FantasyMakerVREditor`): `Result: Succeeded`, 0 errors.
- `python -m pytest tests/` — 735 passed, 3 skipped.

Added `test_skeletal_mesh_loaders_are_unique_for_unity_builds`, alongside the existing montage equivalent, so the collision cannot silently return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)