### PR TITLE
feat(insights): TraceServices-backed trace analysis, plus fix insights-capture never writing a trace

### DIFF
--- a/soft_ue_cli/__main__.py
+++ b/soft_ue_cli/__main__.py
@@ -3069,6 +3069,14 @@ def cmd_insights_analyze(args: argparse.Namespace) -> None:
         arguments["end_time"] = args.end_time
     if args.hitch_threshold_ms is not None:
         arguments["hitch_threshold_ms"] = args.hitch_threshold_ms
+    if args.timer_name:
+        arguments["timer_name"] = args.timer_name
+    if args.direction:
+        arguments["direction"] = args.direction
+    if args.max_depth is not None:
+        arguments["max_depth"] = args.max_depth
+    if args.column_filter:
+        arguments["column_filter"] = args.column_filter
     _print_json(_run_tool("insights-analyze", arguments))
 
 
@@ -7632,13 +7640,26 @@ def build_parser(*, include_removed: bool = False) -> argparse.ArgumentParser:
             "  basic_info     File metadata only; does not parse the trace (fast).\n"
             "  frame_stats    Frame timing distribution (avg/median/p90/p95/p99) and hitches.\n"
             "  top_functions  Aggregated CPU/GPU timers ranked by cost.\n"
+            "  call_tree      Caller/callee tree rooted at --timer-name: decomposes a scope.\n"
             "  counters       Trace counters/stats with min/max/average.\n"
+            "  csv_stats      CSV profiler captures - where WorldTickMisc and Ticks/* live.\n"
             "  threads        Threads present in the trace.\n"
             "  bottlenecks    Composite: frame health, worst frames, heaviest timers.\n\n"
+            "NOTE: CPU scopes are compiled out of Shipping builds, so a Shipping capture\n"
+            "contains no timer data at all - package Development or Test to profile.\n"
+            "CSV stats are a separate system from CPU timers: exclusive CSV stats such as\n"
+            "WorldTickMisc are residual buckets, so decompose the CPU scope (UWorld_Tick)\n"
+            "with call_tree rather than looking for the CSV stat name among the timers.\n\n"
             "EXAMPLES:\n"
             "  soft-ue-cli insights-analyze MyTrace.utrace\n"
             "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type bottlenecks\n"
             "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type top_functions --top-n 50\n"
+            "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type call_tree \\\n"
+            "      --timer-name UWorld_Tick --max-depth 6\n"
+            "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type call_tree \\\n"
+            "      --timer-name FSceneRenderer::Render --direction callers\n"
+            "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type csv_stats \\\n"
+            "      --column-filter Ticks/\n"
             "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type frame_stats \\\n"
             "      --start-time 10 --end-time 20 --hitch-threshold-ms 16.7"
         ),
@@ -7651,11 +7672,34 @@ def build_parser(*, include_removed: bool = False) -> argparse.ArgumentParser:
             "basic_info",
             "frame_stats",
             "top_functions",
+            "call_tree",
             "counters",
+            "csv_stats",
             "threads",
             "bottlenecks",
         ],
         help="Analysis type (default: basic_info)",
+    )
+    p_ia.add_argument(
+        "--timer-name",
+        metavar="NAME",
+        help="Timer/scope to root call_tree at, e.g. UWorld_Tick (required for call_tree)",
+    )
+    p_ia.add_argument(
+        "--direction",
+        choices=["callees", "callers"],
+        help="call_tree direction: callees (inside the timer, default) or callers (who invokes it)",
+    )
+    p_ia.add_argument(
+        "--max-depth",
+        type=int,
+        metavar="N",
+        help="Max depth of call_tree (default: 5, max: 32)",
+    )
+    p_ia.add_argument(
+        "--column-filter",
+        metavar="SUBSTR",
+        help="csv_stats: case-insensitive substring selecting columns, e.g. 'Ticks/' or 'WorldTickMisc'",
     )
     p_ia.add_argument(
         "--top-n",

--- a/soft_ue_cli/__main__.py
+++ b/soft_ue_cli/__main__.py
@@ -3061,6 +3061,14 @@ def cmd_insights_analyze(args: argparse.Namespace) -> None:
     arguments: dict = {"trace_file": args.trace_file}
     if args.analysis_type:
         arguments["analysis_type"] = args.analysis_type
+    if args.top_n is not None:
+        arguments["top_n"] = args.top_n
+    if args.start_time is not None:
+        arguments["start_time"] = args.start_time
+    if args.end_time is not None:
+        arguments["end_time"] = args.end_time
+    if args.hitch_threshold_ms is not None:
+        arguments["hitch_threshold_ms"] = args.hitch_threshold_ms
     _print_json(_run_tool("insights-analyze", arguments))
 
 
@@ -7617,16 +7625,62 @@ def build_parser(*, include_removed: bool = False) -> argparse.ArgumentParser:
         "insights-analyze",
         help="Analyze an Unreal Insights trace file.",
         description=(
-            "Parses a .utrace file and returns a structured summary.\n"
+            "Parses a .utrace file with the Unreal Insights TraceServices providers\n"
+            "and returns a structured summary.\n"
             "Use insights-list-traces to find available trace files.\n\n"
+            "ANALYSIS TYPES:\n"
+            "  basic_info     File metadata only; does not parse the trace (fast).\n"
+            "  frame_stats    Frame timing distribution (avg/median/p90/p95/p99) and hitches.\n"
+            "  top_functions  Aggregated CPU/GPU timers ranked by cost.\n"
+            "  counters       Trace counters/stats with min/max/average.\n"
+            "  threads        Threads present in the trace.\n"
+            "  bottlenecks    Composite: frame health, worst frames, heaviest timers.\n\n"
             "EXAMPLES:\n"
             "  soft-ue-cli insights-analyze MyTrace.utrace\n"
-            "  soft-ue-cli insights-analyze D:/Traces/MyTrace.utrace --analysis-type basic_info"
+            "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type bottlenecks\n"
+            "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type top_functions --top-n 50\n"
+            "  soft-ue-cli insights-analyze MyTrace.utrace --analysis-type frame_stats \\\n"
+            "      --start-time 10 --end-time 20 --hitch-threshold-ms 16.7"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p_ia.add_argument("trace_file", help="Path to .utrace file")
-    p_ia.add_argument("--analysis-type", choices=["basic_info"], help="Analysis type (default: basic_info)")
+    p_ia.add_argument(
+        "--analysis-type",
+        choices=[
+            "basic_info",
+            "frame_stats",
+            "top_functions",
+            "counters",
+            "threads",
+            "bottlenecks",
+        ],
+        help="Analysis type (default: basic_info)",
+    )
+    p_ia.add_argument(
+        "--top-n",
+        type=int,
+        metavar="N",
+        help="Max rows for top_functions/counters/bottlenecks (default: 20, max: 500)",
+    )
+    p_ia.add_argument(
+        "--start-time",
+        type=float,
+        metavar="SEC",
+        help="Window start time in seconds from trace start (default: 0)",
+    )
+    p_ia.add_argument(
+        "--end-time",
+        type=float,
+        metavar="SEC",
+        help="Window end time in seconds (default: end of trace)",
+    )
+    p_ia.add_argument(
+        "--hitch-threshold-ms",
+        type=float,
+        metavar="MS",
+        help="Frame time in ms above which a frame counts as a hitch (default: 33.4)",
+    )
     p_ia.set_defaults(func=cmd_insights_analyze)
 
     # -------------------------------------------------------------------------

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
@@ -166,20 +166,32 @@ namespace
 		ETraceFrameType FrameType,
 		const FInsightsAnalysisWindow& Window,
 		TArray<double>& OutDurations,
-		TArray<TraceServices::FFrame>& OutFrames)
+		TArray<TraceServices::FFrame>& OutFrames,
+		int32& OutSkippedFrames)
 	{
+		OutSkippedFrames = 0;
+
 		FrameProvider.EnumerateFrames(
 			FrameType,
 			Window.StartTime,
 			Window.EndTime,
-			[&OutDurations, &OutFrames](const TraceServices::FFrame& Frame)
+			[&OutDurations, &OutFrames, &OutSkippedFrames](const TraceServices::FFrame& Frame)
 			{
 				const double Duration = Frame.EndTime - Frame.StartTime;
-				if (Duration >= 0.0)
+
+				// A frame still open when tracing stopped has no meaningful end time,
+				// which yields an infinite duration. Including even one poisons the
+				// total, max and average (and drives average_fps to zero), so drop
+				// them - but report how many were dropped rather than hiding it.
+				// The comparison also rejects NaN, since NaN compares false.
+				if (!(Duration >= 0.0 && Duration < TNumericLimits<double>::Max()))
 				{
-					OutDurations.Add(Duration);
-					OutFrames.Add(Frame);
+					++OutSkippedFrames;
+					return;
 				}
+
+				OutDurations.Add(Duration);
+				OutFrames.Add(Frame);
 			});
 	}
 
@@ -514,7 +526,13 @@ FBridgeToolResult UInsightsAnalyzeTool::Execute(
 	FInsightsAnalysisWindow Window;
 	Arguments->TryGetNumberField(TEXT("start_time"), Window.StartTime);
 	Arguments->TryGetNumberField(TEXT("end_time"), Window.EndTime);
-	Window.ResolveAgainstSession(*Session);
+	{
+		// GetDurationSeconds() is a session read: it asserts if called outside a
+		// read scope, even though it reads like a plain accessor. Scoped tightly
+		// so the per-analysis scopes below are not nested inside this one.
+		TraceServices::FAnalysisSessionReadScope WindowReadScope(*Session);
+		Window.ResolveAgainstSession(*Session);
+	}
 
 	if (AnalysisType == TEXT("frame_stats"))
 	{
@@ -593,12 +611,14 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeFrameStats(
 {
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetStringField(TEXT("analysis_type"), TEXT("frame_stats"));
-	Result->SetStringField(TEXT("session_name"), Session.GetName() ? Session.GetName() : TEXT(""));
-	Result->SetNumberField(TEXT("trace_duration_seconds"), Session.GetDurationSeconds());
 	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
 	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
 
 	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	// GetName()/GetDurationSeconds() are session reads and must stay inside the scope.
+	Result->SetStringField(TEXT("session_name"), Session.GetName() ? Session.GetName() : TEXT(""));
+	Result->SetNumberField(TEXT("trace_duration_seconds"), Session.GetDurationSeconds());
 
 	const TraceServices::IFrameProvider& FrameProvider = TraceServices::ReadFrameProvider(Session);
 
@@ -611,14 +631,20 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeFrameStats(
 
 		TArray<double> Durations;
 		TArray<TraceServices::FFrame> Frames;
-		CollectFrameDurations(FrameProvider, FrameType, Window, Durations, Frames);
+		int32 SkippedFrames = 0;
+		CollectFrameDurations(FrameProvider, FrameType, Window, Durations, Frames, SkippedFrames);
 
 		if (Durations.Num() > 0)
 		{
 			bAnyFrames = true;
 		}
 
-		ByType->SetObjectField(FrameTypeToString(FrameType), BuildDurationStatsJson(Durations, HitchThresholdMs));
+		TSharedPtr<FJsonObject> TypeStats = BuildDurationStatsJson(Durations, HitchThresholdMs);
+		if (SkippedFrames > 0)
+		{
+			TypeStats->SetNumberField(TEXT("incomplete_frames_skipped"), SkippedFrames);
+		}
+		ByType->SetObjectField(FrameTypeToString(FrameType), TypeStats);
 	}
 
 	Result->SetObjectField(TEXT("frames"), ByType);
@@ -673,9 +699,17 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeTopFunctions(
 		}
 	}
 
-	Result->SetNumberField(TEXT("timer_count"), static_cast<double>(Table->GetRowCount()));
+	// GetRowCount() is the aggregation's row count, which TableEntryLimit has already
+	// capped - it is NOT how many timers the trace contains, so don't name it that.
+	Result->SetNumberField(TEXT("returned_count"), static_cast<double>(Timers.Num()));
 	Result->SetArrayField(TEXT("timers"), Timers);
 	Result->SetStringField(TEXT("sorted_by"), TEXT("total_inclusive_ms"));
+	if (Timers.Num() >= TopN)
+	{
+		Result->SetStringField(
+			TEXT("note"),
+			TEXT("Results are capped at top_n; raise it to see more timers."));
+	}
 
 	return FBridgeToolResult::Json(Result);
 }
@@ -1049,19 +1083,23 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeBottlenecks(
 {
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetStringField(TEXT("analysis_type"), TEXT("bottlenecks"));
-	Result->SetStringField(TEXT("session_name"), Session.GetName() ? Session.GetName() : TEXT(""));
-	Result->SetNumberField(TEXT("trace_duration_seconds"), Session.GetDurationSeconds());
 	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
 	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
 
 	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	// GetName()/GetDurationSeconds() are session reads and must stay inside the scope.
+	Result->SetStringField(TEXT("session_name"), Session.GetName() ? Session.GetName() : TEXT(""));
+	Result->SetNumberField(TEXT("trace_duration_seconds"), Session.GetDurationSeconds());
 
 	// --- Frame health, and the worst frames worth jumping to in the Insights UI ---
 	const TraceServices::IFrameProvider& FrameProvider = TraceServices::ReadFrameProvider(Session);
 
 	TArray<double> GameDurations;
 	TArray<TraceServices::FFrame> GameFrames;
-	CollectFrameDurations(FrameProvider, TraceFrameType_Game, Window, GameDurations, GameFrames);
+	int32 SkippedGameFrames = 0;
+	CollectFrameDurations(
+		FrameProvider, TraceFrameType_Game, Window, GameDurations, GameFrames, SkippedGameFrames);
 
 	// BuildDurationStatsJson sorts its input, so capture worst frames from the
 	// unsorted frame list first.
@@ -1092,7 +1130,12 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeBottlenecks(
 		WorstFrames.Add(MakeShareable(new FJsonValueObject(FrameJson)));
 	}
 
-	Result->SetObjectField(TEXT("game_frames"), BuildDurationStatsJson(GameDurations, HitchThresholdMs));
+	TSharedPtr<FJsonObject> GameFrameStats = BuildDurationStatsJson(GameDurations, HitchThresholdMs);
+	if (SkippedGameFrames > 0)
+	{
+		GameFrameStats->SetNumberField(TEXT("incomplete_frames_skipped"), SkippedGameFrames);
+	}
+	Result->SetObjectField(TEXT("game_frames"), GameFrameStats);
 	Result->SetArrayField(TEXT("worst_frames"), WorstFrames);
 
 	// --- Heaviest timers: inclusive cost, plus self-cost for narrowing the culprit ---

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
@@ -4,10 +4,262 @@
 #include "SoftUEBridgeEditorModule.h"
 #include "Misc/Paths.h"
 #include "HAL/FileManager.h"
+#include "Modules/ModuleManager.h"
+
+#include "TraceServices/AnalysisService.h"
+#include "TraceServices/ITraceServicesModule.h"
+#include "TraceServices/Model/AnalysisSession.h"
+#include "TraceServices/Model/Counters.h"
+#include "TraceServices/Model/Frames.h"
+#include "TraceServices/Model/Threads.h"
+#include "TraceServices/Model/TimingProfiler.h"
+
+namespace
+{
+	/** Default number of rows returned by the aggregating analyses. */
+	constexpr int32 InsightsDefaultTopN = 20;
+	constexpr int32 InsightsMaxTopN = 500;
+
+	/** A frame slower than this is reported as a hitch unless the caller overrides it. */
+	constexpr double InsightsDefaultHitchThresholdMs = 33.4;
+
+	/** Worst-frame samples included in the bottlenecks report. */
+	constexpr int32 InsightsWorstFrameCount = 10;
+
+	/**
+	 * Runs a full analysis pass over a trace file and returns the completed session.
+	 * IAnalysisService::Analyze() is synchronous - it blocks until the trace has been
+	 * fully parsed - which is what we want for a one-shot CLI query.
+	 */
+	TSharedPtr<const TraceServices::IAnalysisSession> OpenTraceSession(const FString& TraceFile, FString& OutError)
+	{
+		ITraceServicesModule* TraceServicesModule =
+			FModuleManager::Get().LoadModulePtr<ITraceServicesModule>(TEXT("TraceServices"));
+		if (!TraceServicesModule)
+		{
+			OutError = TEXT("TraceServices module is not available in this editor build.");
+			return nullptr;
+		}
+
+		TSharedPtr<TraceServices::IAnalysisService> AnalysisService = TraceServicesModule->GetAnalysisService();
+		if (!AnalysisService.IsValid())
+		{
+			OutError = TEXT("TraceServices analysis service could not be created.");
+			return nullptr;
+		}
+
+		TSharedPtr<const TraceServices::IAnalysisSession> Session = AnalysisService->Analyze(*TraceFile);
+		if (!Session.IsValid())
+		{
+			OutError = FString::Printf(
+				TEXT("Failed to analyze trace file '%s'. It may be truncated, still being written, or not a .utrace file."),
+				*TraceFile);
+			return nullptr;
+		}
+
+		return Session;
+	}
+
+	/** Linear-interpolated percentile over an already sorted array. */
+	double PercentileOfSorted(const TArray<double>& SortedValues, double Fraction)
+	{
+		if (SortedValues.Num() == 0)
+		{
+			return 0.0;
+		}
+		if (SortedValues.Num() == 1)
+		{
+			return SortedValues[0];
+		}
+
+		const double Position = Fraction * static_cast<double>(SortedValues.Num() - 1);
+		const int32 LowIndex = FMath::Clamp(FMath::FloorToInt32(Position), 0, SortedValues.Num() - 1);
+		const int32 HighIndex = FMath::Clamp(LowIndex + 1, 0, SortedValues.Num() - 1);
+		const double Alpha = Position - static_cast<double>(LowIndex);
+
+		return FMath::Lerp(SortedValues[LowIndex], SortedValues[HighIndex], Alpha);
+	}
+
+	/**
+	 * Builds the distribution block shared by the frame analyses.
+	 * Sorts Values in place.
+	 */
+	TSharedPtr<FJsonObject> BuildDurationStatsJson(TArray<double>& Values, double HitchThresholdMs)
+	{
+		TSharedPtr<FJsonObject> Stats = MakeShareable(new FJsonObject);
+		Stats->SetNumberField(TEXT("count"), Values.Num());
+
+		if (Values.Num() == 0)
+		{
+			return Stats;
+		}
+
+		Values.Sort();
+
+		double Total = 0.0;
+		int32 HitchCount = 0;
+		const double HitchThresholdSeconds = HitchThresholdMs / 1000.0;
+		for (double Value : Values)
+		{
+			Total += Value;
+			if (Value > HitchThresholdSeconds)
+			{
+				++HitchCount;
+			}
+		}
+
+		const double Average = Total / static_cast<double>(Values.Num());
+
+		Stats->SetNumberField(TEXT("total_time_seconds"), Total);
+		Stats->SetNumberField(TEXT("min_ms"), Values[0] * 1000.0);
+		Stats->SetNumberField(TEXT("max_ms"), Values.Last() * 1000.0);
+		Stats->SetNumberField(TEXT("average_ms"), Average * 1000.0);
+		Stats->SetNumberField(TEXT("median_ms"), PercentileOfSorted(Values, 0.50) * 1000.0);
+		Stats->SetNumberField(TEXT("p90_ms"), PercentileOfSorted(Values, 0.90) * 1000.0);
+		Stats->SetNumberField(TEXT("p95_ms"), PercentileOfSorted(Values, 0.95) * 1000.0);
+		Stats->SetNumberField(TEXT("p99_ms"), PercentileOfSorted(Values, 0.99) * 1000.0);
+		Stats->SetNumberField(TEXT("average_fps"), Average > 0.0 ? 1.0 / Average : 0.0);
+		Stats->SetNumberField(TEXT("hitch_threshold_ms"), HitchThresholdMs);
+		Stats->SetNumberField(TEXT("hitch_count"), HitchCount);
+		Stats->SetNumberField(
+			TEXT("hitch_percent"),
+			100.0 * static_cast<double>(HitchCount) / static_cast<double>(Values.Num()));
+
+		return Stats;
+	}
+
+	const TCHAR* FrameTypeToString(ETraceFrameType FrameType)
+	{
+		switch (FrameType)
+		{
+		case TraceFrameType_Game:
+			return TEXT("game");
+		case TraceFrameType_Rendering:
+			return TEXT("rendering");
+		default:
+			return TEXT("unknown");
+		}
+	}
+
+	const TCHAR* TimerTypeToString(TraceServices::ETimingProfilerTimerType TimerType)
+	{
+		switch (TimerType)
+		{
+		case TraceServices::ETimingProfilerTimerType::CpuScope:
+			return TEXT("cpu_scope");
+		case TraceServices::ETimingProfilerTimerType::CpuSampling:
+			return TEXT("cpu_sampling");
+		case TraceServices::ETimingProfilerTimerType::GpuScope:
+			return TEXT("gpu_scope");
+		case TraceServices::ETimingProfilerTimerType::VerseSampling:
+			return TEXT("verse_sampling");
+		default:
+			return TEXT("unknown");
+		}
+	}
+
+	/** Collects frame durations (in seconds) for a frame type within the window. */
+	void CollectFrameDurations(
+		const TraceServices::IFrameProvider& FrameProvider,
+		ETraceFrameType FrameType,
+		const FInsightsAnalysisWindow& Window,
+		TArray<double>& OutDurations,
+		TArray<TraceServices::FFrame>& OutFrames)
+	{
+		FrameProvider.EnumerateFrames(
+			FrameType,
+			Window.StartTime,
+			Window.EndTime,
+			[&OutDurations, &OutFrames](const TraceServices::FFrame& Frame)
+			{
+				const double Duration = Frame.EndTime - Frame.StartTime;
+				if (Duration >= 0.0)
+				{
+					OutDurations.Add(Duration);
+					OutFrames.Add(Frame);
+				}
+			});
+	}
+
+	/**
+	 * Runs a timer aggregation over the window. Returns nullptr when the trace has no
+	 * timing data (for example a trace captured without the 'cpu' channel).
+	 * Must be called inside an FAnalysisSessionReadScope.
+	 */
+	TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>> CreateTimerAggregation(
+		const TraceServices::ITimingProfilerProvider& TimingProvider,
+		const FInsightsAnalysisWindow& Window,
+		int32 TopN)
+	{
+		TraceServices::FCreateAggregationParams Params;
+		Params.IntervalStart = Window.StartTime;
+		Params.IntervalEnd = Window.EndTime;
+
+		// Aggregate every CPU thread and GPU queue present in the trace.
+		Params.CpuThreadFilter = [](uint32 /*ThreadId*/) { return true; };
+		Params.GpuQueueFilter = [](uint32 /*QueueId*/) { return true; };
+
+		Params.SortBy = TraceServices::FCreateAggregationParams::ESortBy::TotalInclusiveTime;
+		Params.SortOrder = TraceServices::FCreateAggregationParams::ESortOrder::Descending;
+		Params.TableEntryLimit = TopN;
+
+		return TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>>(
+			TimingProvider.CreateAggregation(Params));
+	}
+
+	/** Converts one aggregated timer row to JSON. */
+	TSharedPtr<FJsonObject> AggregatedTimerToJson(const TraceServices::FTimingProfilerAggregatedStats& Row)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+
+		if (Row.Timer)
+		{
+			Json->SetStringField(TEXT("name"), Row.Timer->Name ? Row.Timer->Name : TEXT("<unnamed>"));
+			Json->SetStringField(TEXT("type"), TimerTypeToString(Row.Timer->Type));
+			if (Row.Timer->File)
+			{
+				Json->SetStringField(TEXT("file"), Row.Timer->File);
+				Json->SetNumberField(TEXT("line"), Row.Timer->Line);
+			}
+		}
+		else
+		{
+			Json->SetStringField(TEXT("name"), TEXT("<unknown>"));
+		}
+
+		Json->SetNumberField(TEXT("instance_count"), static_cast<double>(Row.InstanceCount));
+		Json->SetNumberField(TEXT("total_inclusive_ms"), Row.TotalInclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("average_inclusive_ms"), Row.AverageInclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("median_inclusive_ms"), Row.MedianInclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("max_inclusive_ms"), Row.MaxInclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("total_exclusive_ms"), Row.TotalExclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("average_exclusive_ms"), Row.AverageExclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("max_exclusive_ms"), Row.MaxExclusiveTime * 1000.0);
+
+		return Json;
+	}
+} // namespace
+
+void FInsightsAnalysisWindow::ResolveAgainstSession(const TraceServices::IAnalysisSession& Session)
+{
+	const double Duration = Session.GetDurationSeconds();
+
+	if (EndTime <= 0.0 || EndTime > Duration)
+	{
+		EndTime = Duration;
+	}
+	StartTime = FMath::Clamp(StartTime, 0.0, EndTime);
+}
 
 FString UInsightsAnalyzeTool::GetToolDescription() const
 {
-	return TEXT("Analyze Unreal Insights trace files. Currently supports 'basic_info' analysis type (file metadata). Full trace analysis requires TraceAnalysis module integration (future enhancement).");
+	return TEXT(
+		"Analyze Unreal Insights trace files using the TraceServices providers. "
+		"Analysis types: 'basic_info' (file metadata only), 'frame_stats' (frame timing "
+		"distribution and hitches), 'top_functions' (aggregated CPU/GPU timers by cost), "
+		"'counters' (trace counters/stats), 'threads' (threads in the trace), and "
+		"'bottlenecks' (composite report: frame health, worst frames, heaviest timers). "
+		"Supports an optional [start_time, end_time] window.");
 }
 
 TMap<FString, FBridgeSchemaProperty> UInsightsAnalyzeTool::GetInputSchema() const
@@ -22,10 +274,40 @@ TMap<FString, FBridgeSchemaProperty> UInsightsAnalyzeTool::GetInputSchema() cons
 
 	FBridgeSchemaProperty AnalysisType;
 	AnalysisType.Type = TEXT("string");
-	AnalysisType.Description = TEXT("Type of analysis: 'basic_info' (default). Future: 'frame_stats', 'top_functions', 'memory_summary'");
+	AnalysisType.Description = TEXT("Type of analysis to run (default: 'basic_info')");
 	AnalysisType.bRequired = false;
-	AnalysisType.Enum = {TEXT("basic_info")};
+	AnalysisType.Enum = {
+		TEXT("basic_info"),
+		TEXT("frame_stats"),
+		TEXT("top_functions"),
+		TEXT("counters"),
+		TEXT("threads"),
+		TEXT("bottlenecks")};
 	Schema.Add(TEXT("analysis_type"), AnalysisType);
+
+	FBridgeSchemaProperty TopN;
+	TopN.Type = TEXT("integer");
+	TopN.Description = TEXT("Max rows for 'top_functions', 'counters' and 'bottlenecks' (default: 20, max: 500)");
+	TopN.bRequired = false;
+	Schema.Add(TEXT("top_n"), TopN);
+
+	FBridgeSchemaProperty StartTime;
+	StartTime.Type = TEXT("number");
+	StartTime.Description = TEXT("Window start time in seconds from trace start (default: 0)");
+	StartTime.bRequired = false;
+	Schema.Add(TEXT("start_time"), StartTime);
+
+	FBridgeSchemaProperty EndTime;
+	EndTime.Type = TEXT("number");
+	EndTime.Description = TEXT("Window end time in seconds (default: end of trace)");
+	EndTime.bRequired = false;
+	Schema.Add(TEXT("end_time"), EndTime);
+
+	FBridgeSchemaProperty HitchThreshold;
+	HitchThreshold.Type = TEXT("number");
+	HitchThreshold.Description = TEXT("Frame time in ms above which a frame counts as a hitch (default: 33.4)");
+	HitchThreshold.bRequired = false;
+	Schema.Add(TEXT("hitch_threshold_ms"), HitchThreshold);
 
 	return Schema;
 }
@@ -34,51 +316,428 @@ FBridgeToolResult UInsightsAnalyzeTool::Execute(
 	const TSharedPtr<FJsonObject>& Arguments,
 	const FBridgeToolContext& Context)
 {
-	FString TraceFile = GetStringArgOrDefault(Arguments, TEXT("trace_file"));
+	const FString TraceFile = GetStringArgOrDefault(Arguments, TEXT("trace_file"));
 	if (TraceFile.IsEmpty())
 	{
 		return FBridgeToolResult::Error(TEXT("Missing required argument: trace_file"));
 	}
 
-	FString AnalysisType = GetStringArgOrDefault(Arguments, TEXT("analysis_type"), TEXT("basic_info"));
+	const FString AnalysisType = GetStringArgOrDefault(Arguments, TEXT("analysis_type"), TEXT("basic_info"));
 
 	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("insights-analyze: Analyzing %s with type %s"), *TraceFile, *AnalysisType);
 
-	// Check if file exists
 	if (!FPaths::FileExists(TraceFile))
 	{
 		return FBridgeToolResult::Error(FString::Printf(TEXT("Trace file not found: %s"), *TraceFile));
 	}
 
+	// basic_info deliberately avoids parsing the trace so it stays instant on large captures.
 	if (AnalysisType == TEXT("basic_info"))
 	{
 		return AnalyzeBasicInfo(TraceFile);
 	}
-	else
+
+	const int32 TopN = FMath::Clamp(
+		GetIntArgOrDefault(Arguments, TEXT("top_n"), InsightsDefaultTopN),
+		1,
+		InsightsMaxTopN);
+	// Read the time-valued arguments as doubles rather than through the float
+	// helper - long captures lose meaningful precision at float resolution.
+	double HitchThresholdMs = InsightsDefaultHitchThresholdMs;
+	Arguments->TryGetNumberField(TEXT("hitch_threshold_ms"), HitchThresholdMs);
+	HitchThresholdMs = FMath::Max(HitchThresholdMs, 0.0);
+
+	FString OpenError;
+	TSharedPtr<const TraceServices::IAnalysisSession> Session = OpenTraceSession(TraceFile, OpenError);
+	if (!Session.IsValid())
 	{
-		return FBridgeToolResult::Error(FString::Printf(
-			TEXT("Analysis type '%s' not yet implemented. Currently only 'basic_info' is supported. "
-			     "Full trace analysis (frame_stats, top_functions, etc.) requires TraceAnalysis module integration."),
-			*AnalysisType));
+		return FBridgeToolResult::Error(OpenError);
 	}
+
+	FInsightsAnalysisWindow Window;
+	Arguments->TryGetNumberField(TEXT("start_time"), Window.StartTime);
+	Arguments->TryGetNumberField(TEXT("end_time"), Window.EndTime);
+	Window.ResolveAgainstSession(*Session);
+
+	if (AnalysisType == TEXT("frame_stats"))
+	{
+		return AnalyzeFrameStats(*Session, Window, HitchThresholdMs);
+	}
+	if (AnalysisType == TEXT("top_functions"))
+	{
+		return AnalyzeTopFunctions(*Session, Window, TopN);
+	}
+	if (AnalysisType == TEXT("counters"))
+	{
+		return AnalyzeCounters(*Session, Window, TopN);
+	}
+	if (AnalysisType == TEXT("threads"))
+	{
+		return AnalyzeThreads(*Session);
+	}
+	if (AnalysisType == TEXT("bottlenecks"))
+	{
+		return AnalyzeBottlenecks(*Session, Window, TopN, HitchThresholdMs);
+	}
+
+	return FBridgeToolResult::Error(FString::Printf(
+		TEXT("Unknown analysis_type '%s'. Supported: basic_info, frame_stats, top_functions, "
+		     "counters, threads, bottlenecks."),
+		*AnalysisType));
 }
 
 FBridgeToolResult UInsightsAnalyzeTool::AnalyzeBasicInfo(const FString& TraceFile)
 {
 	IFileManager& FileManager = IFileManager::Get();
-
-	// Get file info
-	FFileStatData StatData = FileManager.GetStatData(*TraceFile);
+	const FFileStatData StatData = FileManager.GetStatData(*TraceFile);
 
 	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
 	Result->SetStringField(TEXT("trace_file"), TraceFile);
 	Result->SetStringField(TEXT("file_name"), FPaths::GetCleanFilename(TraceFile));
-	Result->SetNumberField(TEXT("size_bytes"), StatData.FileSize);
+	Result->SetNumberField(TEXT("size_bytes"), static_cast<double>(StatData.FileSize));
 	Result->SetNumberField(TEXT("size_mb"), static_cast<double>(StatData.FileSize) / (1024.0 * 1024.0));
 	Result->SetStringField(TEXT("created"), StatData.CreationTime.ToString(TEXT("%Y-%m-%d %H:%M:%S")));
 	Result->SetStringField(TEXT("modified"), StatData.ModificationTime.ToString(TEXT("%Y-%m-%d %H:%M:%S")));
 	Result->SetStringField(TEXT("analysis_type"), TEXT("basic_info"));
-	Result->SetStringField(TEXT("note"), TEXT("Full trace analysis (frame stats, CPU profiling, etc.) requires TraceAnalysis module integration. Use Unreal Insights standalone application for detailed analysis."));
+	Result->SetStringField(
+		TEXT("note"),
+		TEXT("File metadata only - the trace is not parsed. Use analysis_type 'frame_stats', "
+		     "'top_functions', 'counters', 'threads' or 'bottlenecks' for trace contents."));
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeFrameStats(
+	const TraceServices::IAnalysisSession& Session,
+	const FInsightsAnalysisWindow& Window,
+	double HitchThresholdMs)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("frame_stats"));
+	Result->SetStringField(TEXT("session_name"), Session.GetName() ? Session.GetName() : TEXT(""));
+	Result->SetNumberField(TEXT("trace_duration_seconds"), Session.GetDurationSeconds());
+	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
+	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	const TraceServices::IFrameProvider& FrameProvider = TraceServices::ReadFrameProvider(Session);
+
+	TSharedPtr<FJsonObject> ByType = MakeShareable(new FJsonObject);
+	bool bAnyFrames = false;
+
+	for (int32 TypeIndex = 0; TypeIndex < TraceFrameType_Count; ++TypeIndex)
+	{
+		const ETraceFrameType FrameType = static_cast<ETraceFrameType>(TypeIndex);
+
+		TArray<double> Durations;
+		TArray<TraceServices::FFrame> Frames;
+		CollectFrameDurations(FrameProvider, FrameType, Window, Durations, Frames);
+
+		if (Durations.Num() > 0)
+		{
+			bAnyFrames = true;
+		}
+
+		ByType->SetObjectField(FrameTypeToString(FrameType), BuildDurationStatsJson(Durations, HitchThresholdMs));
+	}
+
+	Result->SetObjectField(TEXT("frames"), ByType);
+
+	if (!bAnyFrames)
+	{
+		Result->SetStringField(
+			TEXT("note"),
+			TEXT("No frames found in this window. The trace may have been captured without the "
+			     "'frame' channel, or the window may fall outside the traced range."));
+	}
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeTopFunctions(
+	const TraceServices::IAnalysisSession& Session,
+	const FInsightsAnalysisWindow& Window,
+	int32 TopN)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("top_functions"));
+	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
+	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
+	Result->SetNumberField(TEXT("top_n"), TopN);
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	const TraceServices::ITimingProfilerProvider* TimingProvider = TraceServices::ReadTimingProfilerProvider(Session);
+	if (!TimingProvider)
+	{
+		return FBridgeToolResult::Error(TEXT(
+			"This trace has no timing data. Capture with the 'cpu' (and optionally 'gpu') "
+			"channel to get timer information."));
+	}
+
+	TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>> Table =
+		CreateTimerAggregation(*TimingProvider, Window, TopN);
+	if (!Table.IsValid())
+	{
+		return FBridgeToolResult::Error(TEXT("Timer aggregation failed for this trace."));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Timers;
+	TUniquePtr<TraceServices::ITableReader<TraceServices::FTimingProfilerAggregatedStats>> Reader(
+		Table->CreateReader());
+	for (; Reader.IsValid() && Reader->IsValid(); Reader->NextRow())
+	{
+		if (const TraceServices::FTimingProfilerAggregatedStats* Row = Reader->GetCurrentRow())
+		{
+			Timers.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(*Row))));
+		}
+	}
+
+	Result->SetNumberField(TEXT("timer_count"), static_cast<double>(Table->GetRowCount()));
+	Result->SetArrayField(TEXT("timers"), Timers);
+	Result->SetStringField(TEXT("sorted_by"), TEXT("total_inclusive_ms"));
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeCounters(
+	const TraceServices::IAnalysisSession& Session,
+	const FInsightsAnalysisWindow& Window,
+	int32 TopN)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("counters"));
+	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
+	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	const TraceServices::ICounterProvider& CounterProvider = TraceServices::ReadCounterProvider(Session);
+
+	TArray<TSharedPtr<FJsonValue>> Counters;
+	int32 TotalCounters = 0;
+
+	CounterProvider.EnumerateCounters(
+		[&Counters, &TotalCounters, &Window, TopN](uint32 /*CounterId*/, const TraceServices::ICounter& Counter)
+		{
+			++TotalCounters;
+			if (Counters.Num() >= TopN)
+			{
+				return;
+			}
+
+			double Min = TNumericLimits<double>::Max();
+			double Max = TNumericLimits<double>::Lowest();
+			double Total = 0.0;
+			int64 SampleCount = 0;
+			double LastValue = 0.0;
+
+			const auto Accumulate = [&Min, &Max, &Total, &SampleCount, &LastValue](double Value)
+			{
+				Min = FMath::Min(Min, Value);
+				Max = FMath::Max(Max, Value);
+				Total += Value;
+				LastValue = Value;
+				++SampleCount;
+			};
+
+			if (Counter.IsFloatingPoint())
+			{
+				Counter.EnumerateFloatValues(
+					Window.StartTime,
+					Window.EndTime,
+					false,
+					[&Accumulate](double /*Time*/, double Value) { Accumulate(Value); });
+			}
+			else
+			{
+				Counter.EnumerateValues(
+					Window.StartTime,
+					Window.EndTime,
+					false,
+					[&Accumulate](double /*Time*/, int64 Value) { Accumulate(static_cast<double>(Value)); });
+			}
+
+			if (SampleCount == 0)
+			{
+				return;
+			}
+
+			TSharedPtr<FJsonObject> CounterJson = MakeShareable(new FJsonObject);
+			CounterJson->SetStringField(TEXT("name"), Counter.GetName() ? Counter.GetName() : TEXT("<unnamed>"));
+			if (Counter.GetGroup())
+			{
+				CounterJson->SetStringField(TEXT("group"), Counter.GetGroup());
+			}
+			CounterJson->SetBoolField(TEXT("is_floating_point"), Counter.IsFloatingPoint());
+			CounterJson->SetNumberField(TEXT("sample_count"), static_cast<double>(SampleCount));
+			CounterJson->SetNumberField(TEXT("min"), Min);
+			CounterJson->SetNumberField(TEXT("max"), Max);
+			CounterJson->SetNumberField(TEXT("average"), Total / static_cast<double>(SampleCount));
+			CounterJson->SetNumberField(TEXT("last"), LastValue);
+
+			Counters.Add(MakeShareable(new FJsonValueObject(CounterJson)));
+		});
+
+	Result->SetNumberField(TEXT("counter_count"), TotalCounters);
+	Result->SetNumberField(TEXT("returned_count"), Counters.Num());
+	Result->SetArrayField(TEXT("counters"), Counters);
+
+	if (TotalCounters > Counters.Num())
+	{
+		Result->SetStringField(
+			TEXT("note"),
+			FString::Printf(
+				TEXT("Showing %d of %d counters (counters without samples in the window are omitted). "
+				     "Raise top_n to see more."),
+				Counters.Num(),
+				TotalCounters));
+	}
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeThreads(const TraceServices::IAnalysisSession& Session)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("threads"));
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	const TraceServices::IThreadProvider& ThreadProvider = TraceServices::ReadThreadProvider(Session);
+
+	TArray<TSharedPtr<FJsonValue>> Threads;
+	ThreadProvider.EnumerateThreads(
+		[&Threads](const TraceServices::FThreadInfo& ThreadInfo)
+		{
+			TSharedPtr<FJsonObject> ThreadJson = MakeShareable(new FJsonObject);
+			ThreadJson->SetNumberField(TEXT("id"), ThreadInfo.Id);
+			ThreadJson->SetStringField(TEXT("name"), ThreadInfo.Name ? ThreadInfo.Name : TEXT("<unnamed>"));
+			if (ThreadInfo.GroupName)
+			{
+				ThreadJson->SetStringField(TEXT("group"), ThreadInfo.GroupName);
+			}
+			Threads.Add(MakeShareable(new FJsonValueObject(ThreadJson)));
+		});
+
+	Result->SetNumberField(TEXT("thread_count"), Threads.Num());
+	Result->SetArrayField(TEXT("threads"), Threads);
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeBottlenecks(
+	const TraceServices::IAnalysisSession& Session,
+	const FInsightsAnalysisWindow& Window,
+	int32 TopN,
+	double HitchThresholdMs)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("bottlenecks"));
+	Result->SetStringField(TEXT("session_name"), Session.GetName() ? Session.GetName() : TEXT(""));
+	Result->SetNumberField(TEXT("trace_duration_seconds"), Session.GetDurationSeconds());
+	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
+	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	// --- Frame health, and the worst frames worth jumping to in the Insights UI ---
+	const TraceServices::IFrameProvider& FrameProvider = TraceServices::ReadFrameProvider(Session);
+
+	TArray<double> GameDurations;
+	TArray<TraceServices::FFrame> GameFrames;
+	CollectFrameDurations(FrameProvider, TraceFrameType_Game, Window, GameDurations, GameFrames);
+
+	// BuildDurationStatsJson sorts its input, so capture worst frames from the
+	// unsorted frame list first.
+	TArray<int32> FrameOrder;
+	FrameOrder.Reserve(GameFrames.Num());
+	for (int32 Index = 0; Index < GameFrames.Num(); ++Index)
+	{
+		FrameOrder.Add(Index);
+	}
+	FrameOrder.Sort(
+		[&GameFrames](int32 A, int32 B)
+		{
+			const double DurationA = GameFrames[A].EndTime - GameFrames[A].StartTime;
+			const double DurationB = GameFrames[B].EndTime - GameFrames[B].StartTime;
+			return DurationA > DurationB;
+		});
+
+	TArray<TSharedPtr<FJsonValue>> WorstFrames;
+	const int32 WorstCount = FMath::Min(InsightsWorstFrameCount, FrameOrder.Num());
+	for (int32 Index = 0; Index < WorstCount; ++Index)
+	{
+		const TraceServices::FFrame& Frame = GameFrames[FrameOrder[Index]];
+
+		TSharedPtr<FJsonObject> FrameJson = MakeShareable(new FJsonObject);
+		FrameJson->SetNumberField(TEXT("index"), static_cast<double>(Frame.Index));
+		FrameJson->SetNumberField(TEXT("start_time_seconds"), Frame.StartTime);
+		FrameJson->SetNumberField(TEXT("duration_ms"), (Frame.EndTime - Frame.StartTime) * 1000.0);
+		WorstFrames.Add(MakeShareable(new FJsonValueObject(FrameJson)));
+	}
+
+	Result->SetObjectField(TEXT("game_frames"), BuildDurationStatsJson(GameDurations, HitchThresholdMs));
+	Result->SetArrayField(TEXT("worst_frames"), WorstFrames);
+
+	// --- Heaviest timers: inclusive cost, plus self-cost for narrowing the culprit ---
+	const TraceServices::ITimingProfilerProvider* TimingProvider = TraceServices::ReadTimingProfilerProvider(Session);
+	if (!TimingProvider)
+	{
+		Result->SetStringField(
+			TEXT("note"),
+			TEXT("This trace has no timing data, so only frame statistics are reported. "
+			     "Capture with the 'cpu' channel to identify expensive timers."));
+		return FBridgeToolResult::Json(Result);
+	}
+
+	TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>> Table =
+		CreateTimerAggregation(*TimingProvider, Window, TopN);
+	if (!Table.IsValid())
+	{
+		Result->SetStringField(TEXT("note"), TEXT("Timer aggregation failed for this trace."));
+		return FBridgeToolResult::Json(Result);
+	}
+
+	// Collect once, then present two orderings: total time spent under a timer
+	// (inclusive) and time spent in the timer itself (exclusive/self).
+	TArray<TraceServices::FTimingProfilerAggregatedStats> Rows;
+	TUniquePtr<TraceServices::ITableReader<TraceServices::FTimingProfilerAggregatedStats>> Reader(
+		Table->CreateReader());
+	for (; Reader.IsValid() && Reader->IsValid(); Reader->NextRow())
+	{
+		if (const TraceServices::FTimingProfilerAggregatedStats* Row = Reader->GetCurrentRow())
+		{
+			Rows.Add(*Row);
+		}
+	}
+
+	TArray<TSharedPtr<FJsonValue>> ByInclusive;
+	for (const TraceServices::FTimingProfilerAggregatedStats& Row : Rows)
+	{
+		ByInclusive.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Row))));
+	}
+
+	Rows.Sort(
+		[](const TraceServices::FTimingProfilerAggregatedStats& A,
+		   const TraceServices::FTimingProfilerAggregatedStats& B)
+		{
+			return A.TotalExclusiveTime > B.TotalExclusiveTime;
+		});
+
+	TArray<TSharedPtr<FJsonValue>> ByExclusive;
+	for (const TraceServices::FTimingProfilerAggregatedStats& Row : Rows)
+	{
+		ByExclusive.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Row))));
+	}
+
+	Result->SetArrayField(TEXT("top_timers_by_inclusive_time"), ByInclusive);
+	Result->SetArrayField(TEXT("top_timers_by_self_time"), ByExclusive);
+	Result->SetStringField(
+		TEXT("hint"),
+		TEXT("'top_timers_by_self_time' isolates where time is actually spent; "
+		     "'top_timers_by_inclusive_time' shows which call trees are most expensive overall."));
 
 	return FBridgeToolResult::Json(Result);
 }

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
@@ -199,11 +199,16 @@ namespace
 	 * Runs a timer aggregation over the window. Returns nullptr when the trace has no
 	 * timing data (for example a trace captured without the 'cpu' channel).
 	 * Must be called inside an FAnalysisSessionReadScope.
+	 *
+	 * TableEntryLimit caps the rows the aggregation emits; 0 means no limit. Pass 0
+	 * whenever the caller needs to rank by anything other than total inclusive time,
+	 * because the limit is applied *after* sorting by inclusive time and would
+	 * otherwise silently exclude rows that lead a different ranking.
 	 */
 	TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>> CreateTimerAggregation(
 		const TraceServices::ITimingProfilerProvider& TimingProvider,
 		const FInsightsAnalysisWindow& Window,
-		int32 TopN)
+		int32 TableEntryLimit)
 	{
 		TraceServices::FCreateAggregationParams Params;
 		Params.IntervalStart = Window.StartTime;
@@ -215,10 +220,26 @@ namespace
 
 		Params.SortBy = TraceServices::FCreateAggregationParams::ESortBy::TotalInclusiveTime;
 		Params.SortOrder = TraceServices::FCreateAggregationParams::ESortOrder::Descending;
-		Params.TableEntryLimit = TopN;
+		Params.TableEntryLimit = TableEntryLimit;
 
 		return TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>>(
 			TimingProvider.CreateAggregation(Params));
+	}
+
+	/** Reads every row of an aggregation table into an array. */
+	void ReadAggregationRows(
+		const TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>& Table,
+		TArray<TraceServices::FTimingProfilerAggregatedStats>& OutRows)
+	{
+		TUniquePtr<TraceServices::ITableReader<TraceServices::FTimingProfilerAggregatedStats>> Reader(
+			Table.CreateReader());
+		for (; Reader.IsValid() && Reader->IsValid(); Reader->NextRow())
+		{
+			if (const TraceServices::FTimingProfilerAggregatedStats* Row = Reader->GetCurrentRow())
+			{
+				OutRows.Add(*Row);
+			}
+		}
 	}
 
 	/** Default and maximum depth of the caller/callee tree. */
@@ -688,15 +709,13 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeTopFunctions(
 		return FBridgeToolResult::Error(TEXT("Timer aggregation failed for this trace."));
 	}
 
+	TArray<TraceServices::FTimingProfilerAggregatedStats> Rows;
+	ReadAggregationRows(*Table, Rows);
+
 	TArray<TSharedPtr<FJsonValue>> Timers;
-	TUniquePtr<TraceServices::ITableReader<TraceServices::FTimingProfilerAggregatedStats>> Reader(
-		Table->CreateReader());
-	for (; Reader.IsValid() && Reader->IsValid(); Reader->NextRow())
+	for (const TraceServices::FTimingProfilerAggregatedStats& Row : Rows)
 	{
-		if (const TraceServices::FTimingProfilerAggregatedStats* Row = Reader->GetCurrentRow())
-		{
-			Timers.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(*Row))));
-		}
+		Timers.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Row))));
 	}
 
 	// GetRowCount() is the aggregation's row count, which TableEntryLimit has already
@@ -1149,31 +1168,37 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeBottlenecks(
 		return FBridgeToolResult::Json(Result);
 	}
 
+	// Aggregate WITHOUT a row limit. TableEntryLimit is applied after sorting by
+	// total inclusive time, so limiting here would make the self-time ranking below
+	// a mere re-sort of the heaviest call trees - and a timer with huge self time
+	// but modest inclusive time would be omitted from the very list meant to find it.
 	TUniquePtr<TraceServices::ITable<TraceServices::FTimingProfilerAggregatedStats>> Table =
-		CreateTimerAggregation(*TimingProvider, Window, TopN);
+		CreateTimerAggregation(*TimingProvider, Window, 0);
 	if (!Table.IsValid())
 	{
 		Result->SetStringField(TEXT("note"), TEXT("Timer aggregation failed for this trace."));
 		return FBridgeToolResult::Json(Result);
 	}
 
-	// Collect once, then present two orderings: total time spent under a timer
-	// (inclusive) and time spent in the timer itself (exclusive/self).
 	TArray<TraceServices::FTimingProfilerAggregatedStats> Rows;
-	TUniquePtr<TraceServices::ITableReader<TraceServices::FTimingProfilerAggregatedStats>> Reader(
-		Table->CreateReader());
-	for (; Reader.IsValid() && Reader->IsValid(); Reader->NextRow())
-	{
-		if (const TraceServices::FTimingProfilerAggregatedStats* Row = Reader->GetCurrentRow())
+	ReadAggregationRows(*Table, Rows);
+	Result->SetNumberField(TEXT("timers_considered"), Rows.Num());
+
+	// Rank the full set independently for each metric: total time spent under a
+	// timer (inclusive) and time spent in the timer itself (exclusive/self).
+	const int32 EmitCount = FMath::Min(TopN, Rows.Num());
+
+	Rows.Sort(
+		[](const TraceServices::FTimingProfilerAggregatedStats& A,
+		   const TraceServices::FTimingProfilerAggregatedStats& B)
 		{
-			Rows.Add(*Row);
-		}
-	}
+			return A.TotalInclusiveTime > B.TotalInclusiveTime;
+		});
 
 	TArray<TSharedPtr<FJsonValue>> ByInclusive;
-	for (const TraceServices::FTimingProfilerAggregatedStats& Row : Rows)
+	for (int32 Index = 0; Index < EmitCount; ++Index)
 	{
-		ByInclusive.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Row))));
+		ByInclusive.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Rows[Index]))));
 	}
 
 	Rows.Sort(
@@ -1184,16 +1209,17 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeBottlenecks(
 		});
 
 	TArray<TSharedPtr<FJsonValue>> ByExclusive;
-	for (const TraceServices::FTimingProfilerAggregatedStats& Row : Rows)
+	for (int32 Index = 0; Index < EmitCount; ++Index)
 	{
-		ByExclusive.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Row))));
+		ByExclusive.Add(MakeShareable(new FJsonValueObject(AggregatedTimerToJson(Rows[Index]))));
 	}
 
 	Result->SetArrayField(TEXT("top_timers_by_inclusive_time"), ByInclusive);
 	Result->SetArrayField(TEXT("top_timers_by_self_time"), ByExclusive);
 	Result->SetStringField(
 		TEXT("hint"),
-		TEXT("'top_timers_by_self_time' isolates where time is actually spent; "
+		TEXT("Both lists are ranked over every timer in the window, not a shared shortlist. "
+		     "'top_timers_by_self_time' isolates where time is actually spent; "
 		     "'top_timers_by_inclusive_time' shows which call trees are most expensive overall."));
 
 	return FBridgeToolResult::Json(Result);

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp
@@ -9,7 +9,9 @@
 #include "TraceServices/AnalysisService.h"
 #include "TraceServices/ITraceServicesModule.h"
 #include "TraceServices/Model/AnalysisSession.h"
+#include "TraceServices/Containers/Tables.h"
 #include "TraceServices/Model/Counters.h"
+#include "TraceServices/Model/CsvProfilerProvider.h"
 #include "TraceServices/Model/Frames.h"
 #include "TraceServices/Model/Threads.h"
 #include "TraceServices/Model/TimingProfiler.h"
@@ -207,6 +209,131 @@ namespace
 			TimingProvider.CreateAggregation(Params));
 	}
 
+	/** Default and maximum depth of the caller/callee tree. */
+	constexpr int32 InsightsDefaultCallTreeDepth = 5;
+	constexpr int32 InsightsMaxCallTreeDepth = 32;
+
+	/** Cap on how many near-miss timer names are offered when a lookup fails. */
+	constexpr int32 InsightsMaxTimerCandidates = 25;
+
+	/**
+	 * Resolves a timer name to its id. Exact (case-insensitive) match wins; if there
+	 * is none, OutCandidates is filled with substring matches so the caller can
+	 * report something actionable instead of just "not found".
+	 * Must be called inside an FAnalysisSessionReadScope.
+	 */
+	bool ResolveTimerId(
+		const TraceServices::ITimingProfilerProvider& TimingProvider,
+		const FString& TimerName,
+		uint32& OutTimerId,
+		TArray<FString>& OutCandidates)
+	{
+		bool bFound = false;
+
+		// The scan body, shared by both engine paths below.
+		auto ScanTimers =
+			[&TimerName, &OutTimerId, &OutCandidates, &bFound](const TraceServices::ITimingProfilerTimerReader& Reader)
+		{
+			const uint32 TimerCount = Reader.GetTimerCount();
+
+			for (uint32 Index = 0; Index < TimerCount; ++Index)
+			{
+				const TraceServices::FTimingProfilerTimer* Timer = Reader.GetTimer(Index);
+				if (Timer && Timer->Name && TimerName.Equals(Timer->Name, ESearchCase::IgnoreCase))
+				{
+					OutTimerId = Timer->Id;
+					bFound = true;
+					return;
+				}
+			}
+
+			for (uint32 Index = 0; Index < TimerCount && OutCandidates.Num() < InsightsMaxTimerCandidates; ++Index)
+			{
+				const TraceServices::FTimingProfilerTimer* Timer = Reader.GetTimer(Index);
+				if (Timer && Timer->Name && FCString::Stristr(Timer->Name, *TimerName) != nullptr)
+				{
+					OutCandidates.Add(Timer->Name);
+				}
+			}
+		};
+
+		// ReadTimers() was deprecated in UE 5.8 in favour of GetTimerReader(),
+		// which does not exist in 5.7.
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8)
+		ScanTimers(TimingProvider.GetTimerReader());
+#else
+		TimingProvider.ReadTimers(ScanTimers);
+#endif
+
+		return bFound;
+	}
+
+	/**
+	 * Serialises a butterfly node and its children, heaviest first.
+	 * Depth and child count are bounded so a deep tree cannot produce unbounded JSON.
+	 */
+	TSharedPtr<FJsonObject> ButterflyNodeToJson(
+		const TraceServices::FTimingProfilerButterflyNode& Node,
+		int32 Depth,
+		int32 MaxDepth,
+		int32 MaxChildren)
+	{
+		TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+
+		Json->SetStringField(
+			TEXT("name"),
+			(Node.Timer && Node.Timer->Name) ? Node.Timer->Name : TEXT("<unknown>"));
+		Json->SetNumberField(TEXT("count"), static_cast<double>(Node.Count));
+		Json->SetNumberField(TEXT("inclusive_ms"), Node.InclusiveTime * 1000.0);
+		Json->SetNumberField(TEXT("exclusive_ms"), Node.ExclusiveTime * 1000.0);
+
+		TArray<const TraceServices::FTimingProfilerButterflyNode*> Children;
+		Children.Reserve(Node.Children.Num());
+		for (const TraceServices::FTimingProfilerButterflyNode* Child : Node.Children)
+		{
+			if (Child)
+			{
+				Children.Add(Child);
+			}
+		}
+
+		if (Children.Num() == 0)
+		{
+			return Json;
+		}
+
+		if (Depth >= MaxDepth)
+		{
+			// Report what was cut so a truncated tree is never mistaken for a leaf.
+			Json->SetNumberField(TEXT("omitted_children"), Children.Num());
+			Json->SetBoolField(TEXT("depth_limited"), true);
+			return Json;
+		}
+
+		Children.Sort(
+			[](const TraceServices::FTimingProfilerButterflyNode& A,
+			   const TraceServices::FTimingProfilerButterflyNode& B)
+			{
+				return A.InclusiveTime > B.InclusiveTime;
+			});
+
+		const int32 EmittedCount = FMath::Min(MaxChildren, Children.Num());
+		TArray<TSharedPtr<FJsonValue>> ChildrenJson;
+		for (int32 Index = 0; Index < EmittedCount; ++Index)
+		{
+			ChildrenJson.Add(MakeShareable(new FJsonValueObject(
+				ButterflyNodeToJson(*Children[Index], Depth + 1, MaxDepth, MaxChildren))));
+		}
+
+		Json->SetArrayField(TEXT("children"), ChildrenJson);
+		if (Children.Num() > EmittedCount)
+		{
+			Json->SetNumberField(TEXT("omitted_children"), Children.Num() - EmittedCount);
+		}
+
+		return Json;
+	}
+
 	/** Converts one aggregated timer row to JSON. */
 	TSharedPtr<FJsonObject> AggregatedTimerToJson(const TraceServices::FTimingProfilerAggregatedStats& Row)
 	{
@@ -257,8 +384,11 @@ FString UInsightsAnalyzeTool::GetToolDescription() const
 		"Analyze Unreal Insights trace files using the TraceServices providers. "
 		"Analysis types: 'basic_info' (file metadata only), 'frame_stats' (frame timing "
 		"distribution and hitches), 'top_functions' (aggregated CPU/GPU timers by cost), "
-		"'counters' (trace counters/stats), 'threads' (threads in the trace), and "
-		"'bottlenecks' (composite report: frame health, worst frames, heaviest timers). "
+		"'call_tree' (caller/callee butterfly tree rooted at a named timer - decomposes "
+		"what runs inside a scope), 'counters' (trace counters/stats), 'csv_stats' (CSV "
+		"profiler captures - where WorldTickMisc and Ticks/* live; these are NOT CPU "
+		"timers), 'threads' (threads in the trace), and 'bottlenecks' (composite report: "
+		"frame health, worst frames, heaviest timers). "
 		"Supports an optional [start_time, end_time] window.");
 }
 
@@ -280,10 +410,37 @@ TMap<FString, FBridgeSchemaProperty> UInsightsAnalyzeTool::GetInputSchema() cons
 		TEXT("basic_info"),
 		TEXT("frame_stats"),
 		TEXT("top_functions"),
+		TEXT("call_tree"),
 		TEXT("counters"),
+		TEXT("csv_stats"),
 		TEXT("threads"),
 		TEXT("bottlenecks")};
 	Schema.Add(TEXT("analysis_type"), AnalysisType);
+
+	FBridgeSchemaProperty TimerName;
+	TimerName.Type = TEXT("string");
+	TimerName.Description = TEXT("Timer/scope to root the 'call_tree' at, e.g. 'UWorld_Tick' (required for call_tree)");
+	TimerName.bRequired = false;
+	Schema.Add(TEXT("timer_name"), TimerName);
+
+	FBridgeSchemaProperty Direction;
+	Direction.Type = TEXT("string");
+	Direction.Description = TEXT("For 'call_tree': 'callees' (what runs inside the timer, default) or 'callers' (who invokes it)");
+	Direction.bRequired = false;
+	Direction.Enum = {TEXT("callees"), TEXT("callers")};
+	Schema.Add(TEXT("direction"), Direction);
+
+	FBridgeSchemaProperty MaxDepth;
+	MaxDepth.Type = TEXT("integer");
+	MaxDepth.Description = TEXT("Max depth of the 'call_tree' (default: 5, max: 32)");
+	MaxDepth.bRequired = false;
+	Schema.Add(TEXT("max_depth"), MaxDepth);
+
+	FBridgeSchemaProperty ColumnFilter;
+	ColumnFilter.Type = TEXT("string");
+	ColumnFilter.Description = TEXT("For 'csv_stats': case-insensitive substring to select columns, e.g. 'WorldTickMisc' or 'Ticks/'. Omit to summarise the first top_n columns.");
+	ColumnFilter.bRequired = false;
+	Schema.Add(TEXT("column_filter"), ColumnFilter);
 
 	FBridgeSchemaProperty TopN;
 	TopN.Type = TEXT("integer");
@@ -367,9 +524,31 @@ FBridgeToolResult UInsightsAnalyzeTool::Execute(
 	{
 		return AnalyzeTopFunctions(*Session, Window, TopN);
 	}
+	if (AnalysisType == TEXT("call_tree"))
+	{
+		const FString TimerName = GetStringArgOrDefault(Arguments, TEXT("timer_name"));
+		if (TimerName.IsEmpty())
+		{
+			return FBridgeToolResult::Error(TEXT(
+				"analysis_type 'call_tree' requires 'timer_name' (the scope to root the tree at). "
+				"Run analysis_type 'top_functions' first to see the timer names present in this trace."));
+		}
+
+		const bool bCallers = GetStringArgOrDefault(Arguments, TEXT("direction"), TEXT("callees")) == TEXT("callers");
+		const int32 MaxDepth = FMath::Clamp(
+			GetIntArgOrDefault(Arguments, TEXT("max_depth"), InsightsDefaultCallTreeDepth),
+			1,
+			InsightsMaxCallTreeDepth);
+
+		return AnalyzeCallTree(*Session, Window, TimerName, bCallers, MaxDepth, TopN);
+	}
 	if (AnalysisType == TEXT("counters"))
 	{
 		return AnalyzeCounters(*Session, Window, TopN);
+	}
+	if (AnalysisType == TEXT("csv_stats"))
+	{
+		return AnalyzeCsvStats(*Session, GetStringArgOrDefault(Arguments, TEXT("column_filter")), TopN);
 	}
 	if (AnalysisType == TEXT("threads"))
 	{
@@ -382,7 +561,7 @@ FBridgeToolResult UInsightsAnalyzeTool::Execute(
 
 	return FBridgeToolResult::Error(FString::Printf(
 		TEXT("Unknown analysis_type '%s'. Supported: basic_info, frame_stats, top_functions, "
-		     "counters, threads, bottlenecks."),
+		     "call_tree, counters, csv_stats, threads, bottlenecks."),
 		*AnalysisType));
 }
 
@@ -497,6 +676,241 @@ FBridgeToolResult UInsightsAnalyzeTool::AnalyzeTopFunctions(
 	Result->SetNumberField(TEXT("timer_count"), static_cast<double>(Table->GetRowCount()));
 	Result->SetArrayField(TEXT("timers"), Timers);
 	Result->SetStringField(TEXT("sorted_by"), TEXT("total_inclusive_ms"));
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeCallTree(
+	const TraceServices::IAnalysisSession& Session,
+	const FInsightsAnalysisWindow& Window,
+	const FString& TimerName,
+	bool bCallers,
+	int32 MaxDepth,
+	int32 TopN)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("call_tree"));
+	Result->SetStringField(TEXT("timer_name"), TimerName);
+	Result->SetStringField(TEXT("direction"), bCallers ? TEXT("callers") : TEXT("callees"));
+	Result->SetNumberField(TEXT("max_depth"), MaxDepth);
+	Result->SetNumberField(TEXT("window_start_seconds"), Window.StartTime);
+	Result->SetNumberField(TEXT("window_end_seconds"), Window.EndTime);
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	const TraceServices::ITimingProfilerProvider* TimingProvider = TraceServices::ReadTimingProfilerProvider(Session);
+	if (!TimingProvider)
+	{
+		return FBridgeToolResult::Error(TEXT(
+			"This trace has no timing data, so there is no call tree to build. Capture with the "
+			"'cpu' channel. Note that CPU scopes are compiled out of Shipping builds entirely "
+			"(CPUPROFILERTRACE_ENABLED is 0 when UE_BUILD_SHIPPING), so a Shipping capture can "
+			"never contain them - package Development or Test instead."));
+	}
+
+	uint32 TimerId = 0;
+	TArray<FString> Candidates;
+	if (!ResolveTimerId(*TimingProvider, TimerName, TimerId, Candidates))
+	{
+		FString Message = FString::Printf(TEXT("No timer named '%s' in this trace."), *TimerName);
+		if (Candidates.Num() > 0)
+		{
+			Message += FString::Printf(
+				TEXT(" Did you mean one of: %s?"),
+				*FString::Join(Candidates, TEXT(", ")));
+		}
+		else
+		{
+			Message += TEXT(
+				" Run analysis_type 'top_functions' to list the timers present. Note that CSV "
+				"profiler stats (WorldTickMisc, Ticks/*) are NOT CPU timers and never appear "
+				"here - use analysis_type 'csv_stats' for those.");
+		}
+		return FBridgeToolResult::Error(Message);
+	}
+
+	TraceServices::FCreateButterflyParams Params;
+	Params.IntervalStart = Window.StartTime;
+	Params.IntervalEnd = Window.EndTime;
+	Params.CpuThreadFilter = [](uint32 /*ThreadId*/) { return true; };
+	Params.GpuQueueFilter = [](uint32 /*QueueId*/) { return true; };
+
+	TUniquePtr<TraceServices::ITimingProfilerButterfly> Butterfly(TimingProvider->CreateButterfly(Params));
+	if (!Butterfly.IsValid())
+	{
+		return FBridgeToolResult::Error(TEXT("Butterfly aggregation failed for this trace."));
+	}
+
+	const TraceServices::FTimingProfilerButterflyNode& Root =
+		bCallers ? Butterfly->GenerateCallersTree(TimerId) : Butterfly->GenerateCalleesTree(TimerId);
+
+	Result->SetObjectField(TEXT("tree"), ButterflyNodeToJson(Root, 0, MaxDepth, TopN));
+	Result->SetStringField(
+		TEXT("hint"),
+		bCallers
+			? TEXT("'callers' shows which call sites reach this timer and how much time each contributes.")
+			: TEXT("'callees' decomposes this timer: a child's inclusive_ms is time spent under it, "
+			       "while the root's own exclusive_ms is time not attributed to any traced child - "
+			       "if that dominates, the trace has no finer instrumentation to give."));
+
+	return FBridgeToolResult::Json(Result);
+}
+
+FBridgeToolResult UInsightsAnalyzeTool::AnalyzeCsvStats(
+	const TraceServices::IAnalysisSession& Session,
+	const FString& ColumnFilter,
+	int32 TopN)
+{
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("analysis_type"), TEXT("csv_stats"));
+	if (!ColumnFilter.IsEmpty())
+	{
+		Result->SetStringField(TEXT("column_filter"), ColumnFilter);
+	}
+
+	TraceServices::FAnalysisSessionReadScope ReadScope(Session);
+
+	const TraceServices::ICsvProfilerProvider* CsvProvider = TraceServices::ReadCsvProfilerProvider(Session);
+	if (!CsvProvider)
+	{
+		return FBridgeToolResult::Error(TEXT(
+			"This trace contains no CSV profiler captures. Capture with the 'csv' channel "
+			"(or run with -csvprofile alongside tracing) to record CSV stats such as "
+			"WorldTickMisc and Ticks/*."));
+	}
+
+	// Capture ids first: GetTable() cannot be called from inside EnumerateCaptures'
+	// callback without re-entering the provider.
+	struct FCaptureRecord
+	{
+		uint32 Id = 0;
+		FString Filename;
+		uint32 FrameCount = 0;
+	};
+	TArray<FCaptureRecord> CaptureRecords;
+
+	CsvProvider->EnumerateCaptures(
+		[&CaptureRecords](const TraceServices::FCaptureInfo& Info)
+		{
+			FCaptureRecord Record;
+			Record.Id = Info.Id;
+			Record.Filename = Info.Filename ? Info.Filename : TEXT("");
+			Record.FrameCount = Info.FrameCount;
+			CaptureRecords.Add(Record);
+		});
+
+	TArray<TSharedPtr<FJsonValue>> CapturesJson;
+	for (const FCaptureRecord& Record : CaptureRecords)
+	{
+		const TraceServices::IUntypedTable& Table = CsvProvider->GetTable(Record.Id);
+		const TraceServices::ITableLayout& Layout = Table.GetLayout();
+		const uint64 ColumnCount = Layout.GetColumnCount();
+
+		TSharedPtr<FJsonObject> CaptureJson = MakeShareable(new FJsonObject);
+		CaptureJson->SetNumberField(TEXT("capture_id"), Record.Id);
+		CaptureJson->SetStringField(TEXT("filename"), Record.Filename);
+		CaptureJson->SetNumberField(TEXT("frame_count"), Record.FrameCount);
+		CaptureJson->SetNumberField(TEXT("row_count"), static_cast<double>(Table.GetRowCount()));
+		CaptureJson->SetNumberField(TEXT("column_count"), static_cast<double>(ColumnCount));
+
+		// Every column name is cheap to list and is what lets an agent discover
+		// what to filter on, so always return the full set.
+		TArray<TSharedPtr<FJsonValue>> AllNames;
+		TArray<uint64> SelectedColumns;
+		for (uint64 ColumnIndex = 0; ColumnIndex < ColumnCount; ++ColumnIndex)
+		{
+			const TCHAR* ColumnName = Layout.GetColumnName(ColumnIndex);
+			const FString NameString = ColumnName ? ColumnName : TEXT("");
+			AllNames.Add(MakeShareable(new FJsonValueString(NameString)));
+
+			const TraceServices::ETableColumnType ColumnType = Layout.GetColumnType(ColumnIndex);
+			const bool bNumeric =
+				ColumnType == TraceServices::TableColumnType_Int ||
+				ColumnType == TraceServices::TableColumnType_Float ||
+				ColumnType == TraceServices::TableColumnType_Double;
+			if (!bNumeric)
+			{
+				continue;
+			}
+
+			const bool bMatches = ColumnFilter.IsEmpty()
+				? SelectedColumns.Num() < TopN
+				: NameString.Contains(ColumnFilter, ESearchCase::IgnoreCase);
+			if (bMatches && SelectedColumns.Num() < TopN)
+			{
+				SelectedColumns.Add(ColumnIndex);
+			}
+		}
+		CaptureJson->SetArrayField(TEXT("column_names"), AllNames);
+
+		// One pass over rows, reading every selected column per row.
+		TArray<double> Totals;
+		TArray<double> Mins;
+		TArray<double> Maxs;
+		TArray<double> Lasts;
+		Totals.Init(0.0, SelectedColumns.Num());
+		Mins.Init(TNumericLimits<double>::Max(), SelectedColumns.Num());
+		Maxs.Init(TNumericLimits<double>::Lowest(), SelectedColumns.Num());
+		Lasts.Init(0.0, SelectedColumns.Num());
+		int64 RowsRead = 0;
+
+		if (SelectedColumns.Num() > 0)
+		{
+			TUniquePtr<TraceServices::IUntypedTableReader> Reader(Table.CreateReader());
+			for (; Reader.IsValid() && Reader->IsValid(); Reader->NextRow())
+			{
+				for (int32 Slot = 0; Slot < SelectedColumns.Num(); ++Slot)
+				{
+					const double Value = Reader->GetValueDouble(SelectedColumns[Slot]);
+					Totals[Slot] += Value;
+					Mins[Slot] = FMath::Min(Mins[Slot], Value);
+					Maxs[Slot] = FMath::Max(Maxs[Slot], Value);
+					Lasts[Slot] = Value;
+				}
+				++RowsRead;
+			}
+		}
+
+		TArray<TSharedPtr<FJsonValue>> ColumnsJson;
+		for (int32 Slot = 0; Slot < SelectedColumns.Num(); ++Slot)
+		{
+			const TCHAR* ColumnName = Layout.GetColumnName(SelectedColumns[Slot]);
+
+			TSharedPtr<FJsonObject> ColumnJson = MakeShareable(new FJsonObject);
+			ColumnJson->SetStringField(TEXT("name"), ColumnName ? ColumnName : TEXT(""));
+			ColumnJson->SetNumberField(TEXT("sample_count"), static_cast<double>(RowsRead));
+			if (RowsRead > 0)
+			{
+				ColumnJson->SetNumberField(TEXT("min"), Mins[Slot]);
+				ColumnJson->SetNumberField(TEXT("max"), Maxs[Slot]);
+				ColumnJson->SetNumberField(TEXT("average"), Totals[Slot] / static_cast<double>(RowsRead));
+				ColumnJson->SetNumberField(TEXT("total"), Totals[Slot]);
+				ColumnJson->SetNumberField(TEXT("last"), Lasts[Slot]);
+			}
+			ColumnsJson.Add(MakeShareable(new FJsonValueObject(ColumnJson)));
+		}
+		CaptureJson->SetArrayField(TEXT("columns"), ColumnsJson);
+
+		if (ColumnFilter.IsEmpty() && ColumnCount > static_cast<uint64>(SelectedColumns.Num()))
+		{
+			CaptureJson->SetStringField(
+				TEXT("note"),
+				TEXT("No column_filter given, so only the first numeric columns were summarised. "
+				     "Pick names from 'column_names' and pass column_filter to target them."));
+		}
+
+		CapturesJson.Add(MakeShareable(new FJsonValueObject(CaptureJson)));
+	}
+
+	Result->SetNumberField(TEXT("capture_count"), CapturesJson.Num());
+	Result->SetArrayField(TEXT("captures"), CapturesJson);
+	Result->SetStringField(
+		TEXT("hint"),
+		TEXT("CSV stats are a separate instrumentation system from Insights CPU timers. "
+		     "Exclusive CSV stats such as WorldTickMisc are residual buckets - time in a scope "
+		     "that no other CSV stat claimed - so a large value names an accounting gap, not a "
+		     "slow function. Use analysis_type 'call_tree' on the corresponding CPU scope "
+		     "(e.g. UWorld_Tick) to decompose it."));
 
 	return FBridgeToolResult::Json(Result);
 }

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsCaptureTool.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsCaptureTool.cpp
@@ -101,9 +101,17 @@ FBridgeToolResult UInsightsCaptureTool::StartCapture(const TSharedPtr<FJsonObjec
 		OutputFile = FString::Printf(TEXT("BridgeTrace_%s.utrace"), *Timestamp);
 	}
 
-	// Build trace file path
-	FString TraceDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Profiling"));
+	// Build trace file path. ProjectSavedDir() is relative to the engine binaries
+	// directory, so make it absolute - the trace path is reported back to callers
+	// and is later handed to insights-analyze.
+	FString TraceDir = FPaths::ConvertRelativePathToFull(
+		FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("Profiling")));
 	IFileManager::Get().MakeDirectory(*TraceDir, true);
+
+	if (!OutputFile.EndsWith(TEXT(".utrace")))
+	{
+		OutputFile += TEXT(".utrace");
+	}
 	FString TraceFilePath = FPaths::Combine(TraceDir, OutputFile);
 
 	// Build channel string
@@ -112,34 +120,43 @@ FBridgeToolResult UInsightsCaptureTool::StartCapture(const TSharedPtr<FJsonObjec
 	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("insights-capture: Starting trace with channels: %s"), *ChannelString);
 	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("insights-capture: Output file: %s"), *TraceFilePath);
 
-	// Use the documented console command shape: filename first, channels second.
-	FString StartCommand = FString::Printf(TEXT("Trace.Start \"%s\" %s"), *TraceFilePath, *ChannelString);
-
-	// Execute trace start via console command
-	if (GEngine && GEngine->Exec(nullptr, *StartCommand))
+	// Call FTraceAuxiliary directly rather than issuing "Trace.File <path> <channels>".
+	// UE splits console command arguments on whitespace without honouring quotes, so
+	// any project path containing a space (e.g. "Unreal Projects") arrives as 3+ args
+	// and the command is rejected with "Invalid arguments". Worse, GEngine->Exec still
+	// returns true because the command was *handled*, so the failure was silent.
+	// This API takes the path as a real parameter and returns a genuine success bool.
+	if (!FTraceAuxiliary::Start(
+			FTraceAuxiliary::EConnectionType::File,
+			*TraceFilePath,
+			*ChannelString,
+			nullptr,
+			LogSoftUEBridgeEditor))
 	{
-		GBridgeInsightsCaptureRequested = true;
-		GBridgeInsightsTraceFile = TraceFilePath;
+		return FBridgeToolResult::Error(FString::Printf(
+			TEXT("Failed to start trace capture to '%s'. Check the editor log for the reason "
+			     "(a trace connection may already be active, or the path may not be writable)."),
+			*TraceFilePath));
+	}
 
-		TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
-		Result->SetStringField(TEXT("status"), TEXT("started"));
-		Result->SetStringField(TEXT("trace_file"), TraceFilePath);
-		Result->SetArrayField(TEXT("channels"), [&Channels]()
+	GBridgeInsightsCaptureRequested = true;
+	GBridgeInsightsTraceFile = TraceFilePath;
+
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	Result->SetStringField(TEXT("status"), TEXT("started"));
+	Result->SetStringField(TEXT("trace_file"), TraceFilePath);
+	Result->SetBoolField(TEXT("is_capturing"), FTraceAuxiliary::IsConnected());
+	Result->SetArrayField(TEXT("channels"), [&Channels]()
+	{
+		TArray<TSharedPtr<FJsonValue>> ChannelsJson;
+		for (const FString& Channel : Channels)
 		{
-			TArray<TSharedPtr<FJsonValue>> ChannelsJson;
-			for (const FString& Channel : Channels)
-			{
-				ChannelsJson.Add(MakeShareable(new FJsonValueString(Channel)));
-			}
-			return ChannelsJson;
-		}());
+			ChannelsJson.Add(MakeShareable(new FJsonValueString(Channel)));
+		}
+		return ChannelsJson;
+	}());
 
-		return FBridgeToolResult::Json(Result);
-	}
-	else
-	{
-		return FBridgeToolResult::Error(TEXT("Failed to start trace capture. Ensure Trace system is available."));
-	}
+	return FBridgeToolResult::Json(Result);
 }
 
 FBridgeToolResult UInsightsCaptureTool::StopCapture()
@@ -154,34 +171,37 @@ FBridgeToolResult UInsightsCaptureTool::StopCapture()
 
 	UE_LOG(LogSoftUEBridgeEditor, Log, TEXT("insights-capture: Stopping trace"));
 
-	// Stop trace
-	if (GEngine && GEngine->Exec(nullptr, TEXT("Trace.Stop")))
+	// Stop via the API for the same reason as StartCapture: GEngine->Exec reports
+	// whether the command was handled, not whether tracing actually stopped.
+	const bool bStopped = FTraceAuxiliary::Stop();
+
+	GBridgeInsightsCaptureRequested = false;
+
+	TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
+	if (!bStopped && !FTraceAuxiliary::IsConnected())
 	{
-		GBridgeInsightsCaptureRequested = false;
-
-		TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
-		Result->SetStringField(TEXT("status"), TEXT("stopped"));
-		Result->SetStringField(TEXT("message"), TEXT("Trace capture stopped successfully"));
-		if (!GBridgeInsightsTraceFile.IsEmpty())
-		{
-			Result->SetStringField(TEXT("trace_file"), GBridgeInsightsTraceFile);
-		}
-
+		Result->SetStringField(TEXT("status"), TEXT("idle"));
+		Result->SetStringField(TEXT("message"), TEXT("Trace capture was already inactive"));
 		return FBridgeToolResult::Json(Result);
 	}
-	else
-	{
-		if (!FTraceAuxiliary::IsConnected())
-		{
-			GBridgeInsightsCaptureRequested = false;
 
-			TSharedPtr<FJsonObject> Result = MakeShareable(new FJsonObject);
-			Result->SetStringField(TEXT("status"), TEXT("idle"));
-			Result->SetStringField(TEXT("message"), TEXT("Trace capture was already inactive"));
-			return FBridgeToolResult::Json(Result);
-		}
-		return FBridgeToolResult::Error(TEXT("Failed to stop trace capture"));
+	if (FTraceAuxiliary::IsConnected())
+	{
+		return FBridgeToolResult::Error(TEXT("Failed to stop trace capture; the trace connection is still active."));
 	}
+
+	Result->SetStringField(TEXT("status"), TEXT("stopped"));
+	Result->SetStringField(TEXT("message"), TEXT("Trace capture stopped successfully"));
+	if (!GBridgeInsightsTraceFile.IsEmpty())
+	{
+		Result->SetStringField(TEXT("trace_file"), GBridgeInsightsTraceFile);
+
+		// The file is only complete once tracing has stopped, so report whether it
+		// actually landed rather than leaving the caller to discover an absent file.
+		Result->SetBoolField(TEXT("trace_file_exists"), FPaths::FileExists(GBridgeInsightsTraceFile));
+	}
+
+	return FBridgeToolResult::Json(Result);
 }
 
 FBridgeToolResult UInsightsCaptureTool::GetStatus()

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Performance/InsightsAnalyzeTool.h
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Performance/InsightsAnalyzeTool.h
@@ -6,9 +6,30 @@
 #include "Tools/BridgeToolBase.h"
 #include "InsightsAnalyzeTool.generated.h"
 
+namespace TraceServices
+{
+	class IAnalysisSession;
+}
+
+/** Time window to restrict an analysis to. An unset window covers the whole trace. */
+struct FInsightsAnalysisWindow
+{
+	double StartTime = 0.0;
+	double EndTime = 0.0;
+
+	/** Clamps the window to the session duration, defaulting to the full trace. */
+	void ResolveAgainstSession(const TraceServices::IAnalysisSession& Session);
+};
+
 /**
- * Tool for analyzing Unreal Insights trace files
- * Analysis types: frame_stats, basic_info
+ * Tool for analyzing Unreal Insights trace files.
+ *
+ * Backed by the TraceServices analysis providers, so it reads the same data the
+ * Unreal Insights UI does: frame timings, aggregated CPU/GPU timers, counters
+ * and threads.
+ *
+ * Analysis types: basic_info, frame_stats, top_functions, counters, threads,
+ * bottlenecks.
  */
 UCLASS()
 class SOFTUEBRIDGEEDITOR_API UInsightsAnalyzeTool : public UBridgeToolBase
@@ -22,6 +43,34 @@ public:
 	virtual FBridgeToolResult Execute(const TSharedPtr<FJsonObject>& Arguments, const FBridgeToolContext& Context) override;
 
 private:
-	/** Get basic trace file info */
+	/** Trace file metadata only. Does not parse the trace, so it stays cheap. */
 	FBridgeToolResult AnalyzeBasicInfo(const FString& TraceFile);
+
+	/** Frame counts and timing distribution (avg/median/percentiles) plus hitch counts. */
+	FBridgeToolResult AnalyzeFrameStats(
+		const TraceServices::IAnalysisSession& Session,
+		const FInsightsAnalysisWindow& Window,
+		double HitchThresholdMs);
+
+	/** Aggregated CPU/GPU timers, sorted by total inclusive time. */
+	FBridgeToolResult AnalyzeTopFunctions(
+		const TraceServices::IAnalysisSession& Session,
+		const FInsightsAnalysisWindow& Window,
+		int32 TopN);
+
+	/** Trace counters (stats) with min/max/average over the window. */
+	FBridgeToolResult AnalyzeCounters(
+		const TraceServices::IAnalysisSession& Session,
+		const FInsightsAnalysisWindow& Window,
+		int32 TopN);
+
+	/** Threads present in the trace. */
+	FBridgeToolResult AnalyzeThreads(const TraceServices::IAnalysisSession& Session);
+
+	/** Composite report: frame health, worst frames, and the heaviest timers. */
+	FBridgeToolResult AnalyzeBottlenecks(
+		const TraceServices::IAnalysisSession& Session,
+		const FInsightsAnalysisWindow& Window,
+		int32 TopN,
+		double HitchThresholdMs);
 };

--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Performance/InsightsAnalyzeTool.h
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Public/Tools/Performance/InsightsAnalyzeTool.h
@@ -28,8 +28,8 @@ struct FInsightsAnalysisWindow
  * Unreal Insights UI does: frame timings, aggregated CPU/GPU timers, counters
  * and threads.
  *
- * Analysis types: basic_info, frame_stats, top_functions, counters, threads,
- * bottlenecks.
+ * Analysis types: basic_info, frame_stats, top_functions, call_tree, counters,
+ * csv_stats, threads, bottlenecks.
  */
 UCLASS()
 class SOFTUEBRIDGEEDITOR_API UInsightsAnalyzeTool : public UBridgeToolBase
@@ -56,6 +56,28 @@ private:
 	FBridgeToolResult AnalyzeTopFunctions(
 		const TraceServices::IAnalysisSession& Session,
 		const FInsightsAnalysisWindow& Window,
+		int32 TopN);
+
+	/**
+	 * Caller/callee (butterfly) tree rooted at a named timer - the hierarchical
+	 * "what is actually inside this scope" view that a flat aggregation cannot give.
+	 */
+	FBridgeToolResult AnalyzeCallTree(
+		const TraceServices::IAnalysisSession& Session,
+		const FInsightsAnalysisWindow& Window,
+		const FString& TimerName,
+		bool bCallers,
+		int32 MaxDepth,
+		int32 TopN);
+
+	/**
+	 * CSV profiler captures embedded in the trace. This is where the CSV-only
+	 * stats live (WorldTickMisc, Ticks/*, ...) - they are NOT CPU timers and do
+	 * not appear in top_functions or call_tree.
+	 */
+	FBridgeToolResult AnalyzeCsvStats(
+		const TraceServices::IAnalysisSession& Session,
+		const FString& ColumnFilter,
 		int32 TopN);
 
 	/** Trace counters (stats) with min/max/average over the window. */

--- a/tests/test_plugin_descriptor.py
+++ b/tests/test_plugin_descriptor.py
@@ -1840,6 +1840,16 @@ def test_insights_analyze_reads_traces_through_trace_services_providers():
     for field in ("median_ms", "p90_ms", "p95_ms", "p99_ms", "hitch_count"):
         assert field in source
 
+    # A frame still open when tracing stops has an infinite duration, and even one
+    # poisons total/max/average and drives average_fps to zero. Drop them, but say so.
+    assert "incomplete_frames_skipped" in source
+    assert "TNumericLimits<double>::Max()" in source
+
+    # GetRowCount() is already capped by TableEntryLimit, so it must not be
+    # presented as the number of timers in the trace.
+    assert '"timer_count"' not in source
+    assert "returned_count" in source
+
     assert "FInsightsAnalysisWindow" in header
 
 

--- a/tests/test_plugin_descriptor.py
+++ b/tests/test_plugin_descriptor.py
@@ -1819,7 +1819,9 @@ def test_insights_analyze_reads_traces_through_trace_services_providers():
         "basic_info",
         "frame_stats",
         "top_functions",
+        "call_tree",
         "counters",
+        "csv_stats",
         "threads",
         "bottlenecks",
     ):
@@ -1873,9 +1875,90 @@ def test_insights_analyze_cli_exposes_every_analysis_type():
         "basic_info",
         "frame_stats",
         "top_functions",
+        "call_tree",
         "counters",
+        "csv_stats",
         "threads",
         "bottlenecks",
     ):
         parsed = parser.parse_args(["insights-analyze", "T.utrace", "--analysis-type", analysis_type])
         assert parsed.analysis_type == analysis_type
+
+    tree = parser.parse_args(
+        [
+            "insights-analyze",
+            "T.utrace",
+            "--analysis-type",
+            "call_tree",
+            "--timer-name",
+            "UWorld_Tick",
+            "--direction",
+            "callers",
+            "--max-depth",
+            "6",
+        ]
+    )
+    assert tree.timer_name == "UWorld_Tick"
+    assert tree.direction == "callers"
+    assert tree.max_depth == 6
+
+    csv = parser.parse_args(
+        ["insights-analyze", "T.utrace", "--analysis-type", "csv_stats", "--column-filter", "Ticks/"]
+    )
+    assert csv.column_filter == "Ticks/"
+
+
+def test_insights_call_tree_uses_butterfly_and_resolves_timer_names():
+    source = _plugin_source_path(
+        "Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp"
+    ).read_text(encoding="utf-8")
+
+    # The butterfly aggregation is the hierarchical view a flat aggregation cannot give.
+    assert "CreateButterfly" in source
+    assert "GenerateCalleesTree" in source
+    assert "GenerateCallersTree" in source
+    assert "FCreateButterflyParams" in source
+
+    # Callers pass a timer *name*; it has to be resolved to an id via the timer reader.
+    assert "ResolveTimerId" in source
+    assert "GetTimerCount" in source
+
+    # ReadTimers() was deprecated in 5.8 for GetTimerReader(), which 5.7 lacks -
+    # both paths must stay guarded or one engine version breaks.
+    assert "GetTimerReader()" in source
+    assert "ReadTimers(ScanTimers)" in source
+    assert "ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 8" in source
+
+    # A failed lookup must suggest near-misses rather than just failing.
+    assert "Did you mean one of" in source
+
+    # A truncated tree must never be mistaken for a leaf.
+    assert "omitted_children" in source
+    assert "depth_limited" in source
+
+    # Shipping strips CPU scopes entirely - the error has to say so, since no
+    # amount of re-analysis will recover them.
+    assert "CPUPROFILERTRACE_ENABLED" in source
+    assert "UE_BUILD_SHIPPING" in source
+
+
+def test_insights_csv_stats_reads_the_csv_profiler_provider():
+    source = _plugin_source_path(
+        "Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp"
+    ).read_text(encoding="utf-8")
+
+    # CSV stats live in their own provider, separate from CPU timers and counters.
+    assert "ReadCsvProfilerProvider" in source
+    assert "EnumerateCaptures" in source
+    assert "GetTable" in source
+    assert "ITableLayout" in source
+    assert "IUntypedTableReader" in source
+
+    # Column names are cheap to list and are how an agent discovers what to filter on.
+    assert "column_names" in source
+    assert "column_filter" in source
+
+    # The residual-bucket nature of exclusive CSV stats is the key interpretive
+    # point; without it a large WorldTickMisc reads as "a slow function".
+    assert "WorldTickMisc" in source
+    assert "residual" in source

--- a/tests/test_plugin_descriptor.py
+++ b/tests/test_plugin_descriptor.py
@@ -1785,3 +1785,97 @@ def test_trigger_input_routes_keys_through_player_controller_and_enhanced_input(
     assert "FindEnhancedInputAction" in source
     assert '"EnhancedInput"' in build_cs
     assert '"Name": "EnhancedInput"' in descriptor
+
+
+def test_insights_analyze_reads_traces_through_trace_services_providers():
+    source = _plugin_source_path(
+        "Source/SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp"
+    ).read_text(encoding="utf-8")
+    header = _plugin_source_path(
+        "Source/SoftUEBridgeEditor/Public/Tools/Performance/InsightsAnalyzeTool.h"
+    ).read_text(encoding="utf-8")
+    build_cs = _plugin_source_path(
+        "Source/SoftUEBridgeEditor/SoftUEBridgeEditor.Build.cs"
+    ).read_text(encoding="utf-8")
+
+    assert '"TraceServices"' in build_cs
+    assert '"TraceAnalysis"' in build_cs
+
+    # The trace must actually be parsed, not just stat()-ed as it was before.
+    assert "ITraceServicesModule" in source
+    assert "GetAnalysisService" in source
+    assert "AnalysisService->Analyze" in source
+    # Every provider read has to happen under the session read lock.
+    assert "FAnalysisSessionReadScope" in source
+
+    # One provider per analysis type.
+    assert "ReadFrameProvider" in source
+    assert "ReadTimingProfilerProvider" in source
+    assert "ReadCounterProvider" in source
+    assert "ReadThreadProvider" in source
+    assert "CreateAggregation" in source
+
+    for analysis_type in (
+        "basic_info",
+        "frame_stats",
+        "top_functions",
+        "counters",
+        "threads",
+        "bottlenecks",
+    ):
+        assert f'TEXT("{analysis_type}")' in source
+
+    # Aggregation must span every CPU thread and GPU queue, not a filtered subset.
+    assert "Params.CpuThreadFilter" in source
+    assert "Params.GpuQueueFilter" in source
+
+    # Reporting both orderings is what makes the bottleneck report actionable:
+    # self time localises the cost, inclusive time shows the expensive call tree.
+    assert "top_timers_by_inclusive_time" in source
+    assert "top_timers_by_self_time" in source
+
+    # Percentiles matter more than averages for hitch hunting.
+    for field in ("median_ms", "p90_ms", "p95_ms", "p99_ms", "hitch_count"):
+        assert field in source
+
+    assert "FInsightsAnalysisWindow" in header
+
+
+def test_insights_analyze_cli_exposes_every_analysis_type():
+    from soft_ue_cli.__main__ import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "insights-analyze",
+            "T.utrace",
+            "--analysis-type",
+            "bottlenecks",
+            "--top-n",
+            "50",
+            "--start-time",
+            "10",
+            "--end-time",
+            "20",
+            "--hitch-threshold-ms",
+            "16.7",
+        ]
+    )
+
+    assert args.trace_file == "T.utrace"
+    assert args.analysis_type == "bottlenecks"
+    assert args.top_n == 50
+    assert args.start_time == 10.0
+    assert args.end_time == 20.0
+    assert args.hitch_threshold_ms == 16.7
+
+    for analysis_type in (
+        "basic_info",
+        "frame_stats",
+        "top_functions",
+        "counters",
+        "threads",
+        "bottlenecks",
+    ):
+        parsed = parser.parse_args(["insights-analyze", "T.utrace", "--analysis-type", analysis_type])
+        assert parsed.analysis_type == analysis_type

--- a/tests/test_plugin_descriptor.py
+++ b/tests/test_plugin_descriptor.py
@@ -1836,6 +1836,18 @@ def test_insights_analyze_reads_traces_through_trace_services_providers():
     assert "top_timers_by_inclusive_time" in source
     assert "top_timers_by_self_time" in source
 
+    # TableEntryLimit is applied AFTER sorting by total inclusive time, so
+    # bottlenecks must aggregate unlimited (0) and rank each metric over the full
+    # set. Limiting first would reduce the self-time list to a re-sort of the
+    # heaviest call trees and omit a timer whose self time leads but whose
+    # inclusive time does not.
+    bottlenecks = source.split("UInsightsAnalyzeTool::AnalyzeBottlenecks(", 1)[1]
+    assert "CreateTimerAggregation(*TimingProvider, Window, 0)" in bottlenecks
+    assert "timers_considered" in bottlenecks
+    assert bottlenecks.count("Rows.Sort(") == 2
+    assert "A.TotalInclusiveTime > B.TotalInclusiveTime" in bottlenecks
+    assert "A.TotalExclusiveTime > B.TotalExclusiveTime" in bottlenecks
+
     # Percentiles matter more than averages for hitch hunting.
     for field in ("median_ms", "p90_ms", "p95_ms", "p99_ms", "hitch_count"):
         assert field in source

--- a/tests/test_plugin_source_compat.py
+++ b/tests/test_plugin_source_compat.py
@@ -225,3 +225,54 @@ def test_legacy_cloth_weight_maps_use_public_runtime_targets_and_section_provena
     assert "rejects an empty combined selection" in spec
     assert "records dual membership through the merge helper" in spec
     assert "round-trips extended target values through read and apply helpers" in spec
+
+
+def test_insights_analyze_reads_session_only_inside_a_read_scope():
+    source = _read("SoftUEBridgeEditor/Private/Tools/Performance/InsightsAnalyzeTool.cpp")
+
+    # IAnalysisSession::GetName()/GetDurationSeconds() look like plain accessors but
+    # are session reads: TraceServices asserts "Trying to read from session outside
+    # of a ReadScope" at runtime. This compiles cleanly either way, so the ordering
+    # has to be pinned by a test.
+    for analysis in ("AnalyzeFrameStats", "AnalyzeBottlenecks"):
+        body = source.split(f"UInsightsAnalyzeTool::{analysis}(", 1)[1]
+        scope_at = body.index("FAnalysisSessionReadScope")
+        assert body.index("Session.GetName()") > scope_at, f"{analysis} reads GetName() before its read scope"
+        assert body.index("Session.GetDurationSeconds()") > scope_at, (
+            f"{analysis} reads GetDurationSeconds() before its read scope"
+        )
+
+    # ResolveAgainstSession() also calls GetDurationSeconds(), so its call site in
+    # Execute() needs its own scope.
+    execute_body = source.split("UInsightsAnalyzeTool::Execute(", 1)[1]
+    resolve_at = execute_body.index("Window.ResolveAgainstSession(")
+    preceding = execute_body[:resolve_at]
+    assert "FAnalysisSessionReadScope" in preceding, (
+        "ResolveAgainstSession() reads the session and must be called inside a read scope"
+    )
+
+
+def test_insights_capture_starts_traces_without_console_string_parsing():
+    source = _read("SoftUEBridgeEditor/Private/Tools/Performance/InsightsCaptureTool.cpp")
+
+    # UE splits console command arguments on whitespace without honouring quotes, so
+    # "Trace.File <path> <channels>" is rejected as "Invalid arguments" whenever the
+    # project path contains a space - and GEngine->Exec still returns true because the
+    # command was handled, which made the failure silent.
+    assert "FTraceAuxiliary::Start(" in source
+    assert "FTraceAuxiliary::EConnectionType::File" in source
+    assert "FTraceAuxiliary::Stop()" in source
+
+    # No console command may be executed at all. The comments explaining why still
+    # name Trace.File and GEngine->Exec, so check code lines only.
+    code = "\n".join(
+        line for line in source.splitlines() if not line.strip().startswith("//")
+    )
+    assert "GEngine->Exec" not in code
+    assert "Trace.Start" not in code
+    assert "Trace.Stop" not in code
+
+    # The reported path must be absolute: ProjectSavedDir() is relative to the engine
+    # binaries dir, and the path is handed back to callers for insights-analyze.
+    assert "ConvertRelativePathToFull" in source
+    assert '.utrace' in source


### PR DESCRIPTION
## Summary

`insights-analyze` only ever called `stat()` on the `.utrace` file — the tool's own description said full analysis *"requires TraceAnalysis module integration (future enhancement)"*. `TraceAnalysis` and `TraceServices` were already linked by `SoftUEBridgeEditor` for the Rewind Debugger, so no build-rule change was needed to do it properly.

This also fixes a pre-existing bug that made `insights-capture` produce no trace at all — see part 2, which is why the feature was untestable end-to-end.

## Part 1 — real analysis

The tool now opens the trace with `IAnalysisService::Analyze` and reads the same providers the Unreal Insights UI does, under `FAnalysisSessionReadScope`:

| `analysis_type` | provider |
|---|---|
| `basic_info` | unchanged — file metadata only, still parses nothing so it stays instant on large captures |
| `frame_stats` | `IFrameProvider` — per frame type, avg/median/p90/p95/p99, FPS, hitch counts |
| `top_functions` | `ITimingProfilerProvider::CreateAggregation` over every CPU thread and GPU queue |
| `call_tree` | `CreateButterfly` → `GenerateCalleesTree`/`GenerateCallersTree`, rooted at a named timer |
| `counters` | `ICounterProvider` — min/max/average/last |
| `csv_stats` | `ICsvProfilerProvider` — CSV captures embedded in the trace |
| `threads` | `IThreadProvider` |
| `bottlenecks` | composite — frame health, worst frames, heaviest timers by both inclusive and self time |

All accept an optional `[start_time, end_time]` window plus `top_n` / `hitch_threshold_ms`, exposed on the CLI as `--start-time` / `--end-time` / `--top-n` / `--hitch-threshold-ms`, with `--timer-name` / `--direction` / `--max-depth` for `call_tree` and `--column-filter` for `csv_stats`.

Two design points that matter for agent callers:

- **Percentiles and self time, not just averages.** An average frame time hides exactly the hitches you're hunting, and inclusive time alone cannot distinguish an expensive call tree from an expensive function.
- **`csv_stats` exists because CSV stats are a different instrumentation system.** `WorldTickMisc` and `Ticks/*` are CSV profiler stats, not CPU timers, so they never appear in `top_functions` or `call_tree` — which reads as a tool failure. Worse, `WorldTickMisc` is declared `CSV_SCOPED_TIMING_STAT_EXCLUSIVE` (`LevelTick.cpp:1481`), making it a *residual* bucket: time in `UWorld::Tick` no other CSV stat claimed. A large value names an accounting gap, not a slow function. Asking `call_tree` for it returns that explanation rather than a bare "not found".

Errors are actionable throughout: an unknown timer name returns substring near-misses; a trace with no timing data explains that CPU scopes are compiled out of Shipping entirely (`CPUPROFILERTRACE_ENABLED` is 0 when `UE_BUILD_SHIPPING`), so a Shipping capture can never contain them.

`ITimingProfilerProvider::ReadTimers` was deprecated in 5.8 for `GetTimerReader()`, which does not exist in 5.7, so timer lookup is version-guarded.

## Part 2 — `insights-capture` silently wrote nothing

It issued `Trace.Start "<path>" <channels>`. UE splits console command arguments on whitespace **without honouring quotes**, so any project path containing a space — and `Unreal Projects` is the UE default — arrives as 3+ args and is rejected:

```
Cmd: Trace.Start "../../../Users/.../Unreal Projects/.../SmokeTest" cpu,gpu,frame
LogConsoleResponse: Warning: Invalid arguments. Usage: Trace.File [Path] [ChannelSet]
```

`GEngine->Exec` still returns `true`, because the command *was* handled — so both `start` and `stop` reported success while producing no file. It now calls `FTraceAuxiliary::Start`/`Stop` directly: the path is a real parameter with no parsing, the return value is a genuine success bool, the reported path is absolute (`ProjectSavedDir()` is relative to the engine binaries dir), `.utrace` is appended if missing, and `stop` reports `trace_file_exists`.

## Verification

Smoke-tested against an **85 MB trace captured from a live VR Preview session**, which caught four defects that all compiled cleanly and were only reachable at runtime — each is fixed here and pinned by a regression test:

1. **Crash**: `Trying to read from session outside of a ReadScope`. `IAnalysisSession::GetName()`/`GetDurationSeconds()` read like plain accessors but are locked session reads; three call sites ran before the scope opened.
2. **`inf` in `frame_stats`**: the last frame is still open when tracing stops, and one infinite duration poisoned total/max/average and drove `average_fps` to 0. Non-finite durations are now excluded and reported as `incomplete_frames_skipped`.
3. **Misleading `timer_count`**: it came from `ITable::GetRowCount()`, already capped by `TableEntryLimit`, so `--top-n 12` reported 12 for a trace holding 11,486 timers. Renamed `returned_count`.
4. **`top_timers_by_self_time` was not ranked by self time.** `TableEntryLimit` is applied *after* `SortBy`, so limiting the aggregation by inclusive time reduced the self-time list to a re-sort of the heaviest call trees. At `--top-n 8` it bottomed out at 13.6 ms of self time while omitting `CharacterMesh` at **53,042 ms** — second-largest in the trace — plus `RHIThreadLock_Wait` (35,515 ms), `xrWaitFrame` (31,664 ms) and two others. It now aggregates unlimited (`EntryLimit > 0` gates the cap, so `0` is unlimited) and ranks each metric over the full set, reporting `timers_considered`.

Builds clean — **0 errors and 0 warnings** from these files — on `FantasyMakerVREditor` (**UE 5.7**) and `StarKnightsEditor` (**UE 5.8**, forced clean rebuild so everything is back in unity blobs). `python -m pytest tests/` — 740 passed, 3 skipped.

Sample output from the VR trace, `call_tree` on `Tick_Engine`:

```
Tick_Engine                       incl=68869.6ms  self=453.1ms
  UWorld_Tick                     incl=61796.8ms  self=980.0ms
     OpenXrWaitFrame              incl=31685.1ms  self=2.4ms
        xrWaitFrame               incl=31664.5ms  self=31664.5ms
     TickCompletionEvents         incl=25013.9ms  self=44.9ms
     FActorComponentTickFunction::ExecuteTick   incl=3491.5ms
        Cable                     incl=2146.5ms   self=2146.5ms  x6332
```

## Notes

- `csv_stats` has been exercised against the empty case (`capture_count: 0`) but not yet against a trace containing real CSV captures — UE ignored the `csv` trace channel in my capture, which is consistent with CSV profiling needing to be started separately rather than merely having its channel enabled.
- Independent of #353 and #354; touches no files in common with either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)