### PR TITLE
fix(plugin): clear UE 5.7 cloth deprecation warnings in ClothTools

### DIFF
--- a/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp
+++ b/soft_ue_cli/plugin_data/SoftUEBridge/Source/SoftUEBridgeEditor/Private/Tools/Cloth/ClothTools.cpp
@@ -861,7 +861,9 @@ TSharedPtr<FJsonObject> ChaosClothAssetToJson(
 	Result->SetStringField(TEXT("guid"), Asset->GetAssetGuid(0).ToString(EGuidFormats::DigitsWithHyphens));
 
 	TArray<TSharedPtr<FJsonValue>> LodValues;
-	const TArray<TSharedRef<const FManagedArrayCollection>>& Collections = Asset->GetClothCollections();
+	// Read through a const pointer: the non-const GetClothCollections() is deprecated in 5.7 and slated for removal in 5.9.
+	const UChaosClothAsset* ConstAsset = Asset;
+	const TArray<TSharedRef<const FManagedArrayCollection>>& Collections = ConstAsset->GetClothCollections();
 	for (int32 LodIndex = 0; LodIndex < Collections.Num(); ++LodIndex)
 	{
 		LodValues.Add(MakeShared<FJsonValueObject>(ChaosClothCollectionToJson(Collections[LodIndex], LodIndex, bDumpWeights, DumpWeightMapName, WeightLimit, GapTolerance, GapLimit)));
@@ -943,7 +945,7 @@ bool OutputChaosClothAssetExists(const FString& OutputAssetPath, const FString& 
 		|| FPackageName::DoesPackageExist(PackageName, &PackageFilename);
 }
 
-bool HasChaosClothCollectionData(UChaosClothAsset* Asset)
+bool HasChaosClothCollectionData(const UChaosClothAsset* Asset)
 {
 	if (!Asset)
 	{
@@ -985,7 +987,7 @@ bool ValidateConvertedChaosClothAsset(UChaosClothAsset* Asset, FString& OutError
 }
 
 bool CloneChaosClothCollectionsForLod(
-	UChaosClothAsset* Asset,
+	const UChaosClothAsset* Asset,
 	int32 LodIndex,
 	TArray<TSharedRef<const FManagedArrayCollection>>& OutCollections,
 	TSharedPtr<FManagedArrayCollection>& OutMutableCollection,
@@ -1027,7 +1029,9 @@ bool RebuildChaosClothAsset(
 	const TArray<TSharedRef<const FManagedArrayCollection>>& Collections,
 	FString& OutError)
 {
-	const TArray<TSharedRef<const FManagedArrayCollection>> OriginalCollections = Asset->GetClothCollections();
+	// Snapshot for rollback through a const pointer: the non-const GetClothCollections() is deprecated in 5.7.
+	const UChaosClothAsset* ConstAsset = Asset;
+	const TArray<TSharedRef<const FManagedArrayCollection>> OriginalCollections = ConstAsset->GetClothCollections();
 	FText ErrorText;
 	FText VerboseText;
 	Asset->Build(Collections, nullptr, &ErrorText, &VerboseText);
@@ -1609,7 +1613,10 @@ TSharedPtr<FJsonObject> ClothAssetToJson(UClothingAssetBase* Asset)
 	Json->SetStringField(TEXT("name"), Asset->GetName());
 	Json->SetStringField(TEXT("class"), Asset->GetClass()->GetName());
 	Json->SetStringField(TEXT("guid"), Asset->GetAssetGuid().ToString(EGuidFormats::DigitsWithHyphens));
-	Json->SetNumberField(TEXT("num_lods"), Asset->GetNumLods());
+	// UClothingAssetBase::GetNumLods() is deprecated in 5.7; UClothingAssetCommon's override is not. The other subclass
+	// (UChaosClothAssetSKMClothingAsset) doesn't override it, so the 0 fallback matches the base class's stub return.
+	const UClothingAssetCommon* CommonLodSource = Cast<UClothingAssetCommon>(Asset);
+	Json->SetNumberField(TEXT("num_lods"), CommonLodSource ? CommonLodSource->GetNumLods() : 0);
 
 	if (UClothingAssetCommon* Common = Cast<UClothingAssetCommon>(Asset))
 	{
@@ -3406,7 +3413,11 @@ FBridgeToolResult UClothBindTool::Execute(const TSharedPtr<FJsonObject>& Argumen
 	{
 		return FBridgeToolResult::Error(SectionIndex == INDEX_NONE ? TEXT("section_index is required") : ValidationError);
 	}
-	if (!Asset->IsValidLod(ClothLodIndex))
+	// UClothingAssetBase::IsValidLod() is deprecated in 5.7; UClothingAssetCommon's override is not. The other subclass
+	// (UChaosClothAssetSKMClothingAsset) doesn't override it, so treating a failed cast as invalid matches the base
+	// class's stub return of false.
+	const UClothingAssetCommon* CommonAsset = Cast<UClothingAssetCommon>(Asset);
+	if (!CommonAsset || !CommonAsset->IsValidLod(ClothLodIndex))
 	{
 		return FBridgeToolResult::Error(FString::Printf(TEXT("cloth_lod_index %d is out of range"), ClothLodIndex));
 	}


### PR DESCRIPTION
## Problem

`ClothTools.cpp` emits six `C4996` deprecation warnings against UE 5.7 (and 5.8 — the same deprecations are present in both), from two distinct causes.

**`GetClothCollections()` ×4.** Only the *non-const* overload is deprecated. `ClothAsset.h` (identical in 5.7 and 5.8):

```cpp
UE_DEPRECATED(5.7, "Use SetClothCollections() or GetClothCollectionsInternal() instead.")
TArray<TSharedRef<const FManagedArrayCollection>>& GetClothCollections() { ... }

/** Return the enclosed Cloth Collections. */
const TArray<TSharedRef<const FManagedArrayCollection>>& GetClothCollections() const   // live
```

MSVC picked the deprecated overload because `Asset` was a non-const pointer, even though every call site binds the result to a `const` reference. Following the deprecation message literally is a dead end: `GetClothCollectionsInternal()` is private (its header comment notes it can reclaim the plain name "once the current public method is removed in 5.9").

**`GetNumLods()` / `IsValidLod()` ×2.** The `UClothingAssetBase` virtuals are deprecated; `UClothingAssetCommon`'s overrides are not.

## Fix

**Read through a const pointer.** `HasChaosClothCollectionData` and `CloneChaosClothCollectionsForLod` now take a `const UChaosClothAsset*` (both are read-only anyway); the two functions that still need the non-const asset for `Build()` use a local const alias. This also picks up the const overload's read-only async-property lock, which is what these read paths actually want.

**Call through the derived static type** for the LOD queries. `UClothingAssetBase` has exactly two subclasses, and the other one — `UChaosClothAssetSKMClothingAsset`, which is `final` — overrides neither virtual, so the fallbacks return precisely what the base-class stubs returned (`0` LODs, LOD not valid) and its behaviour is unchanged. `num_lods` stays outside the existing `Cast` block so the JSON field remains unconditionally present.

No version guards are needed: every API this relies on is spelled the same in both engine versions.

## Verification

Each premise checked against both engines' actual headers (`UE_5.7`, `UE_5.8`):

| | 5.7 | 5.8 |
|---|---|---|
| const `GetClothCollections()` exists, non-deprecated | ✅ | ✅ |
| `UClothingAssetCommon::GetNumLods`/`IsValidLod` overrides non-deprecated | ✅ | ✅ |
| Base virtuals `UE_DEPRECATED(5.7, …)`, stubs return `0` / `false` | ✅ | ✅ |
| `UChaosClothAssetSKMClothingAsset` is `final`, overrides neither | ✅ | ✅ |

- **UE 5.8** (`StarKnightsEditor`, forced clean rebuild): `Result: Succeeded`, **0 errors, 0 warnings**, with `Module.SoftUEBridgeEditor.1..5.cpp` compiled and `UnrealEditor-SoftUEBridgeEditor.dll` linked — so the unity blobs were genuinely rebuilt, not skipped.
- `python -m pytest tests/` — 742 passed, 3 skipped.
- **UE 5.7** (`FantasyMakerVREditor`, forced clean rebuild): `Result: Succeeded`, **0 errors, 0 warnings**, with `Module.SoftUEBridgeEditor.1..6.cpp` compiled and `UnrealEditor-SoftUEBridgeEditor.dll` linked.
- **Control run** on the same project with the fix reverted: `Result: Succeeded` with exactly the six `C4996`s, and they are the only warnings in the build —

      ClothTools.cpp(895,80):  warning C4996: 'UChaosClothAsset::GetClothCollections'
      ClothTools.cpp(985,80):  warning C4996: 'UChaosClothAsset::GetClothCollections'
      ClothTools.cpp(1031,80): warning C4996: 'UChaosClothAsset::GetClothCollections'
      ClothTools.cpp(1061,87): warning C4996: 'UChaosClothAsset::GetClothCollections'
      ClothTools.cpp(1643,48): warning C4996: 'UClothingAssetBase::GetNumLods'
      ClothTools.cpp(3441,14): warning C4996: 'UClothingAssetBase::IsValidLod'

  so the clean build above reflects the fix rather than warnings simply not being reported in this configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
